### PR TITLE
Use product keys as the name attribute

### DIFF
--- a/PRODUCT_MATRIX.md
+++ b/PRODUCT_MATRIX.md
@@ -1,0 +1,18 @@
+Update this in lockstep with `#product_matrix` in `libraries/helpers.rb`
+
+| Product | Product Key  | Package Name |
+| ---------- | ------------------ | -------------------- |
+| Chef Client | chef | chef |
+| Chef Development Kit | chefdk| chefdk |
+| Enterprise Chef (legacy) | private-chef | private-chef |
+| Chef Server | chef-server | chef-server (versions < 12.0.0) <br/> chef-server-core (versions >= 12.0.0) |
+| Chef Server High Availability addon | chef-ha | chef-ha |
+| Chef Server Replication addon | chef-sync | chef-sync |
+| Chef Server Reporting addon | reporting | opscode-reporting |
+| Management Console | manage | opscode-manage (versions < 2.0.0) <br/> chef-manage (versions >= 2.0.0) |
+| Push Jobs Server | chef-push-server | opscode-push-jobs-server |
+| Push Jobs Client | chef-push-client | opscode-push-jobs-client (versions < 2.0.0) <br/> chef-push-client (versions >= 2.0.0)  |
+| Analytics Platform | analytics | opscode-analytics |
+| Delivery | delivery | delivery |
+| Delivery CLI | delivery-cli | delivery-cli |
+| Supermarket | supermarket | supermarket |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ A "chef ingredient" is the core package itself, or products or add-on components
 - `reconfigure` - Performs the `ctl reconfigure` command for the package.
 
 #### Properties
-- `package_name`: (name attribute) The name of the package. Should correspond to the published package names (chef-server-core, opscode-manage, etc).
+- `product_name`: (name attribute) The product name. See the `#product_matrix` method in `libraries/helpers.rb` for a list of valid product names. For example, `chef-server`, `analytics`, `delivery`, `manage`, etc.
+- `package_name`: The name of the package in the repository. Should correspond to the published package names (`chef-server-core`, `opscode-manage`, etc).
 - `ctl_command`: The "ctl" command, e.g., `chef-server-ctl`. This should be automatically detected by the library helper method `chef_ctl_command`, but may need to be specified if something changes, like a new add-on is made available.
 - `options`: Options passed to the `package` resource used for installation.
 - `version`: Package version, e.g., `12.0.4`. Do not use if specifying `package_source`. Default `nil`.
@@ -55,7 +56,7 @@ This delegates to the ctl command the service management command specified in th
 #### Properties
 
 - `ctl_command`: The "ctl" command, e.g. `chef-server-ctl`. This should be automatically detected by the library helper method `chef_ctl_command`, but may need to be specified if something changes, like a  new add-on is made available.
-- `service_name`: (name attribute) The name of the service to manage. Specify this like `package_name/service`, for example, `chef-server-core/rabbitmq`.
+- `service_name`: (name attribute) The name of the service to manage. Specify this like `product_name/service`, for example, `chef-server/rabbitmq`.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This cookbook provides primitives - helpers and resources - to manage Chef Softw
 
 It will perform component installation and configuration. It provides no recipes. Instead, wrapper cookbooks should be created using the resources that this cookbook provides.
 
+For a product to package matrix, see [PRODUCT_MATRIX.md](https://github.com/chef-cookbooks/chef-ingredient/blob/master/PRODUCT_MATRIX.md)
+
 ## Requirements
 
 - apt
@@ -37,7 +39,7 @@ A "chef ingredient" is the core package itself, or products or add-on components
 - `reconfigure` - Performs the `ctl reconfigure` command for the package.
 
 #### Properties
-- `product_name`: (name attribute) The product name. See the `#product_matrix` method in `libraries/helpers.rb` for a list of valid product names. For example, `chef-server`, `analytics`, `delivery`, `manage`, etc.
+- `product_name`: (name attribute) The product name. See the [PRODUCT_MATRIX.md](https://github.com/chef-cookbooks/chef-ingredient/blob/master/PRODUCT_MATRIX.md). For example, `chef-server`, `analytics`, `delivery`, `manage`, etc.
 - `package_name`: The name of the package in the repository. Should correspond to the published package names (`chef-server-core`, `opscode-manage`, etc).
 - `ctl_command`: The "ctl" command, e.g., `chef-server-ctl`. This should be automatically detected by the library helper method `chef_ctl_command`, but may need to be specified if something changes, like a new add-on is made available.
 - `options`: Options passed to the `package` resource used for installation.

--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -23,12 +23,13 @@ class Chef
       default_action :install
       state_attrs :installed
 
-      attribute :package_name, kind_of: String, name_attribute: true
+      attribute :product_name, kind_of: String, name_attribute: true
+      attribute :package_name, kind_of: String
       attribute :installed, kind_of: [TrueClass, FalseClass, NilClass], default: false
       attribute :reconfigure, kind_of: [TrueClass, FalseClass], default: false
       attribute :config, kind_of: [Hash, Mash], default: {}
 
-      # Attributes to install package from local file
+      # Attribute to install package from local file
       attribute :package_source, kind_of: String, default: nil
 
       # Attributes for reconfigure step
@@ -36,7 +37,7 @@ class Chef
 
       # Attributes for package
       attribute :options, kind_of: String
-      attribute :version, kind_of: String, default: nil
+      attribute :version, kind_of: String, default: '0.0.0'
       attribute :timeout, kind_of: [Integer, String, NilClass], default: nil
     end
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -18,8 +18,11 @@
 module ChefIngredientCookbook
   module Helpers
     def chef_ctl_command(product)
-      version = new_resource.respond_to?(:version) ? new_resource.version : '0.0.0'
-      product_lookup(product, version)['ctl-command']
+      if new_resource.respond_to?(:version)
+        product_lookup(product, new_resource.version)['ctl-command']
+      else
+        product_lookup(product)['ctl-command']
+      end
     end
 
     def local_package_resource
@@ -96,6 +99,10 @@ module ChefIngredientCookbook
       }
     end
 
+    # Version has a default value of 0.0.0 so that it is a valid
+    # string for the Mixlib::Versioning.parse method. This implies
+    # "latest", but "latest" is not a value that is valid for
+    # mixlib/versioning.
     def product_lookup(product, version = '0.0.0')
       unless product_matrix.has_key?(product)
         Chef::Log.fatal("We don't have a product, '#{product}'. Please specify a valid product name:")
@@ -108,6 +115,11 @@ module ChefIngredientCookbook
 
       data = product_matrix[product]
 
+      # We want to validate that we're getting a version that is valid
+      # for the Chef Server. However, since the default is 0.0.0,
+      # implying latest, we need to additionally ensure that the
+      # bottom version is something valid. If we don't have the check
+      # in the elsif, it will say that 0.0.0 is not a valid version.
       if (product == 'chef-server')
         if (v < Mixlib::Versioning.parse('12.0.0') && v > Mixlib::Versioning.parse('11.0.0'))
           data['package-name'] = 'chef-server'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -18,7 +18,8 @@
 module ChefIngredientCookbook
   module Helpers
     def chef_ctl_command(product)
-      product_lookup(product, new_resource.version)['ctl-command']
+      version = new_resource.respond_to?(:version) ? new_resource.version : '0.0.0'
+      product_lookup(product, version)['ctl-command']
     end
 
     def local_package_resource
@@ -75,6 +76,7 @@ module ChefIngredientCookbook
       end
     end
 
+    # When updating this, also update PRODUCT_MATRIX.md
     def product_matrix
       {
         'analytics'    => {'package-name' => 'opscode-analytics', 'ctl-command' => 'opscode-analytics-ctl' },

--- a/libraries/omnibus_service_resource.rb
+++ b/libraries/omnibus_service_resource.rb
@@ -24,7 +24,6 @@ class Chef
 
       attribute :ctl_command, kind_of: String
       attribute :service_name, kind_of: String, regex: %r{[\w-]+/[\w-]+}, name_attribute: true
-      attribute :version, kind_of: String, default: '0.0.0'
     end
   end
 end

--- a/libraries/omnibus_service_resource.rb
+++ b/libraries/omnibus_service_resource.rb
@@ -24,6 +24,7 @@ class Chef
 
       attribute :ctl_command, kind_of: String
       attribute :service_name, kind_of: String, regex: %r{[\w-]+/[\w-]+}, name_attribute: true
+      attribute :version, kind_of: String, default: '0.0.0'
     end
   end
 end

--- a/spec/centos_65_spec.rb
+++ b/spec/centos_65_spec.rb
@@ -12,11 +12,11 @@ describe 'test::repo on centos' do
       end.converge('test::repo')
     end
 
-    it 'installs chef_ingredient[chef-server-core]' do
-      expect(centos_65).to install_chef_ingredient('chef-server-core')
+    it 'installs chef_ingredient[chef-server]' do
+      expect(centos_65).to install_chef_ingredient('chef-server')
     end
 
-    it 'installs yum_package[chef-server-core]' do
+    it 'installs yum_package[chef-server]' do
       expect(centos_65).to install_yum_package('chef-server-core')
     end
 
@@ -24,8 +24,8 @@ describe 'test::repo on centos' do
       expect(centos_65).to create_file('/tmp/chef-server-core.firstrun')
     end
 
-    it 'installs chef_server_ingredient[opscode-manage]' do
-      expect(centos_65).to install_chef_server_ingredient('opscode-manage')
+    it 'installs chef_server_ingredient[manage]' do
+      expect(centos_65).to install_chef_server_ingredient('manage')
     end
 
     it 'installs yum_package[opscode-manage]' do
@@ -60,10 +60,10 @@ describe 'test::repo on centos' do
   end
 
   context 'package iteration version specified' do
-    cached(:ubuntu_1404) do
+    cached(:centos_65) do
       ChefSpec::SoloRunner.new(
-        platform: 'ubuntu',
-        version: '14.04',
+        platform: 'centos',
+        version: '6.5',
         step_into: ['chef_ingredient']
       ) do |node|
         node.set['test']['chef-server-core']['version'] = '12.0.4-1'
@@ -71,12 +71,12 @@ describe 'test::repo on centos' do
     end
 
     it 'installs the mixlib-versioning gem' do
-      expect(ubuntu_1404).to install_chef_gem('mixlib-versioning')
+      expect(centos_65).to install_chef_gem('mixlib-versioning')
     end
 
     it 'installs the package with the release version string' do
-      expect(ubuntu_1404).to install_apt_package('chef-server-core').with(
-        version: '12.0.4-1'
+      expect(centos_65).to install_yum_package('chef-server-core').with(
+        version: '12.0.4-1.el6'
       )
     end
   end
@@ -117,7 +117,7 @@ describe 'test::local on centos' do
     end
 
     it 'installs chef_ingredient[chef-server-core]' do
-      expect(centos_65).to install_chef_ingredient('chef-server-core')
+      expect(centos_65).to install_chef_ingredient('chef-server')
     end
 
     it 'uses the rpm_package provider instead of yum_package' do

--- a/spec/omnibus_service_spec.rb
+++ b/spec/omnibus_service_spec.rb
@@ -10,7 +10,7 @@ describe 'test::omnibus_service' do
   let(:log_message) { chef_run.log('I tell nginx to stop')}
 
   it 'allows the chef-server-core/rabbitmq service to restart' do
-    expect(chef_run).to restart_omnibus_service('chef-server-core/rabbitmq')
+    expect(chef_run).to restart_omnibus_service('chef-server/rabbitmq')
   end
 
   it 'restarts the rabbitmq service' do
@@ -18,7 +18,7 @@ describe 'test::omnibus_service' do
   end
 
   it 'has a log service that notifies the chef server nginx' do
-    expect(log_message).to notify('omnibus_service[chef-server-core/nginx]').to(:stop)
+    expect(log_message).to notify('omnibus_service[chef-server/nginx]').to(:stop)
   end
 
   it 'starts with a made up service' do

--- a/spec/ubuntu_1404_spec.rb
+++ b/spec/ubuntu_1404_spec.rb
@@ -13,7 +13,7 @@ describe 'test::repo on ubuntu' do
     end
 
     it 'installs chef_ingredient[chef-server-core]' do
-      expect(ubuntu_1404).to install_chef_ingredient('chef-server-core')
+      expect(ubuntu_1404).to install_chef_ingredient('chef-server')
     end
 
     it 'installs apt_package[chef-server-core]' do
@@ -24,8 +24,8 @@ describe 'test::repo on ubuntu' do
       expect(ubuntu_1404).to create_file('/tmp/chef-server-core.firstrun')
     end
 
-    it 'installs chef_server_ingredient[opscode-manage]' do
-      expect(ubuntu_1404).to install_chef_server_ingredient('opscode-manage')
+    it 'installs chef_server_ingredient[manage]' do
+      expect(ubuntu_1404).to install_chef_server_ingredient('manage')
     end
 
     it 'installs apt_package[opscode-manage]' do
@@ -116,8 +116,8 @@ describe 'test::local on ubuntu' do
       end.converge('test::local')
     end
 
-    it 'installs chef_ingredient[chef-server-core]' do
-      expect(ubuntu_1404).to install_chef_ingredient('chef-server-core')
+    it 'installs chef_ingredient[chef-server]' do
+      expect(ubuntu_1404).to install_chef_ingredient('chef-server')
     end
 
     it 'uses the dpkg_package provider instead of apt_package' do

--- a/test/fixtures/cookbooks/test/recipes/local.rb
+++ b/test/fixtures/cookbooks/test/recipes/local.rb
@@ -9,13 +9,13 @@ remote_file "#{cache_path}/#{pkgname}" do
   mode '0644'
 end
 
-chef_ingredient 'chef-server-core' do
+chef_ingredient 'chef-server' do
   package_source "#{cache_path}/#{pkgname}"
   action :install
 end
 
 file '/tmp/chef-server-core.firstrun' do
   content 'ilovechef\n'
-  notifies :reconfigure, 'chef_ingredient[chef-server-core]'
+  notifies :reconfigure, 'chef_ingredient[chef-server]'
   action :create
 end

--- a/test/fixtures/cookbooks/test/recipes/omnibus_service.rb
+++ b/test/fixtures/cookbooks/test/recipes/omnibus_service.rb
@@ -1,15 +1,15 @@
 # we probably don't need/want to add this to a test kitchen suite.
 # This here so we can test with chefspec, really.
-omnibus_service 'chef-server-core/rabbitmq' do
+omnibus_service 'chef-server/rabbitmq' do
   action :restart
 end
 
-omnibus_service 'chef-server-core/nginx' do
+omnibus_service 'chef-server/nginx' do
   action :nothing
 end
 
 log 'I tell nginx to stop' do
-  notifies :stop, 'omnibus_service[chef-server-core/nginx]'
+  notifies :stop, 'omnibus_service[chef-server/nginx]'
 end
 
 omnibus_service 'never-never/land' do

--- a/test/fixtures/cookbooks/test/recipes/repo.rb
+++ b/test/fixtures/cookbooks/test/recipes/repo.rb
@@ -1,22 +1,22 @@
 # Chef Server Core
-chef_ingredient 'chef-server-core' do
+chef_ingredient 'chef-server' do
   version node['test']['chef-server-core']['version']
   action :install
 end
 
 file '/tmp/chef-server-core.firstrun' do
   content 'ilovechef\n'
-  notifies :reconfigure, 'chef_ingredient[chef-server-core]'
+  notifies :reconfigure, 'chef_ingredient[chef-server]'
   action :create
 end
 
 # Management Console - using the compat shim resource
-chef_server_ingredient 'opscode-manage' do
+chef_server_ingredient 'manage' do
   action :install
 end
 
 file '/tmp/opscode-manage.firstrun' do
   content 'ilovechef\n'
-  notifies :reconfigure, 'chef_server_ingredient[opscode-manage]'
+  notifies :reconfigure, 'chef_server_ingredient[manage]'
   action :create
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'chef-ingredient::default' do
-  describe package('chef-server-core') do
+  describe package('chef-server') do
     it { should be_installed }
   end
 
@@ -9,7 +9,7 @@ describe 'chef-ingredient::default' do
     its(:exit_status) { should eq 0 }
   end
 
-  describe package('opscode-manage') do
+  describe package('manage') do
     it { should be_installed }
   end
 

--- a/test/integration/local_package_install/serverspec/assert_local_package_installed_spec.rb
+++ b/test/integration/local_package_install/serverspec/assert_local_package_installed_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'chef-ingredient::default' do
-  describe package('chef-server-core') do
+  describe package('chef-server') do
     it { should be_installed }
   end
 

--- a/test/integration/override_package_versions/serverspec/assert_package_version_installed_spec.rb
+++ b/test/integration/override_package_versions/serverspec/assert_package_version_installed_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'chef-ingredient::default' do
-  describe package('chef-server-core') do
+  describe package('chef-server') do
     it { should be_installed.with_version('12.0.4-1') }
   end
 end


### PR DESCRIPTION
Fixes #1.

Implements a product matrix and product_lookup method that returns a
hash of product information based on the table in #1, with naming
conventions updated to upcoming product updates. It attempts to be
smart so users of the chef_ingredient resource don't need to know the
underlying details about our package naming, especially wrt old
package names.

The product_lookup method also validates that the chef-server package
is selected properly based on the available, supported versions (12
and 11), and fails if the version is specified as > 1.0 and < 11.0,
since we did not publish omnibus packages for those versions.

Add the version attribute to the omnibus_service resource so it can
properly look up the ctl command.