### PR TITLE
Make sure we upgrade the package if :latest is specified

### DIFF
--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -47,6 +47,8 @@ class Chef
         include_recipe "#{package_repo_type}-chef" if new_resource.package_source.nil?
 
         package_resource = new_resource.package_source.nil? ? :package : local_package_resource
+        resource_actions = [:install]
+        resource_actions << :upgrade if new_resource.version.to_sym == :latest
 
         declare_resource package_resource, new_resource.product_name do
           package_name ingredient_package_name
@@ -54,6 +56,7 @@ class Chef
           version install_version if Mixlib::Versioning.parse(version_string(new_resource.version)) > '0.0.0'
           source new_resource.package_source
           timeout new_resource.timeout
+          action resource_actions
         end
       end
 


### PR DESCRIPTION
Currently the resource doesn't upgrade package if it's already installed because in the provider we don't pass a version to the package resource in the event that we use :latest.  I simply add the upgrade action to the package resource when we want latest.