### PR TITLE
Add upgrade action to chef_ingredient

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -57,3 +57,7 @@ suites:
   - name: chefdk
     run_list:
       - recipe[test::chefdk]
+
+  - name: upgrade
+    run_list:
+      - recipe[test::upgrade]

--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -34,27 +34,15 @@ class Chef
       end
 
       action :install do
-        # We need Mixlib::Versioning in the library helpers for
-        # parsing the version string.
-        chef_gem "#{new_resource.product_name}-mixlib-versioning" do #~FC009 foodcritic needs an update
-          package_name 'mixlib-versioning'
-          compile_time true
-        end
+        install_mixlib_versioning
+        create_repository
+        package_resource(:install)
+      end
 
-        require 'mixlib/versioning'
-
-        cleanup_old_repo_config if ::File.exist?(old_ingredient_repo_file)
-        include_recipe "#{package_repo_type}-chef" if new_resource.package_source.nil?
-
-        package_resource = new_resource.package_source.nil? ? :package : local_package_resource
-
-        declare_resource package_resource, new_resource.product_name do
-          package_name ingredient_package_name
-          options new_resource.options
-          version install_version if Mixlib::Versioning.parse(version_string(new_resource.version)) > '0.0.0'
-          source new_resource.package_source
-          timeout new_resource.timeout
-        end
+      action :upgrade do
+        install_mixlib_versioning
+        create_repository
+        package_resource(:upgrade)
       end
 
       action :uninstall do

--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -19,7 +19,7 @@ class Chef
     class ChefIngredient < Chef::Resource::LWRPBase
       self.resource_name = 'chef_ingredient'
 
-      actions :install, :uninstall, :remove, :reconfigure
+      actions :install, :uninstall, :remove, :reconfigure, :upgrade
       default_action :install
       state_attrs :installed
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -56,7 +56,7 @@ module ChefIngredientCookbook
     def install_mixlib_versioning
       # We need Mixlib::Versioning in the library helpers for
       # parsing the version string.
-      chef_gem "#{new_resource.product_name}-mixlib-versioning" do #~FC009 foodcritic needs an update
+      chef_gem "#{new_resource.product_name}-mixlib-versioning" do # ~FC009 foodcritic needs an update
         package_name 'mixlib-versioning'
         compile_time true
       end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -40,6 +40,35 @@ module ChefIngredientCookbook
       :package # fallback if there's no platform match
     end
 
+    def package_resource(ingredient_action)
+      presource = new_resource.package_source.nil? ? :package : local_package_resource
+
+      declare_resource presource, new_resource.product_name do
+        package_name ingredient_package_name
+        options new_resource.options
+        version install_version if Mixlib::Versioning.parse(version_string(new_resource.version)) > '0.0.0'
+        source new_resource.package_source
+        timeout new_resource.timeout
+        action ingredient_action
+      end
+    end
+
+    def install_mixlib_versioning
+      # We need Mixlib::Versioning in the library helpers for
+      # parsing the version string.
+      chef_gem "#{new_resource.product_name}-mixlib-versioning" do #~FC009 foodcritic needs an update
+        package_name 'mixlib-versioning'
+        compile_time true
+      end
+
+      require 'mixlib/versioning'
+    end
+
+    def create_repository
+      cleanup_old_repo_config if ::File.exist?(old_ingredient_repo_file)
+      include_recipe "#{package_repo_type}-chef" if new_resource.package_source.nil?
+    end
+
     def package_repo_type
       return 'apt' if node['platform_family'] == 'debian'
       return 'yum' if node['platform_family'] == 'rhel'

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -3,6 +3,10 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:chef_ingredient, :install, pkg)
   end
 
+  def upgrade_chef_ingredient(pkg)
+    ChefSpec::Matchers::ResourceMatcher.new(:chef_ingredient, :upgrade, pkg)
+  end
+
   def uninstall_chef_ingredient(pkg)
     ChefSpec::Matchers::ResourceMatcher.new(:chef_ingredient, :uninstall, pkg)
   end

--- a/spec/unit/recipes/test_repo_spec.rb
+++ b/spec/unit/recipes/test_repo_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'test::repo' do
   [{ platform: 'ubuntu', version: '14.04' },
-    { platform: 'centos', version: '6.5' }].each do |platform|
+   { platform: 'centos', version: '6.5' }].each do |platform|
     context "non-platform specific resources on #{platform[:platform]}" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(

--- a/spec/unit/recipes/test_upgrade_spec.rb
+++ b/spec/unit/recipes/test_upgrade_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'test::upgrade' do
   [{ platform: 'ubuntu', version: '14.04' },
-    { platform: 'centos', version: '6.5' }].each do |platform|
+   { platform: 'centos', version: '6.5' }].each do |platform|
     context "non-platform specific resources on #{platform[:platform]}" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(

--- a/spec/unit/recipes/test_upgrade_spec.rb
+++ b/spec/unit/recipes/test_upgrade_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe 'test::upgrade' do
+  [{ platform: 'ubuntu', version: '14.04' },
+    { platform: 'centos', version: '6.5' }].each do |platform|
+    context "non-platform specific resources on #{platform[:platform]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform.merge(step_into: ['chef_ingredient'])
+        ).converge(described_recipe)
+      end
+
+      it 'upgrades the chef_ingredient[chef-server]' do
+        expect(chef_run).to upgrade_chef_ingredient('chef-server')
+      end
+    end
+  end
+
+  context 'upgrade packages with yum on centos' do
+    cached(:centos_65) do
+      ChefSpec::SoloRunner.new(
+        platform: 'centos',
+        version: '6.5',
+        step_into: %w(chef_ingredient)
+      ) do |node|
+        node.set['chef-server-core']['version'] = :latest
+      end.converge(described_recipe)
+    end
+
+    it 'upgrades yum_package[chef-server]' do
+      expect(centos_65).to upgrade_yum_package('chef-server-core')
+    end
+  end
+
+  context 'upgrade packages with apt on ubuntu' do
+    cached(:ubuntu_1404) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04',
+        step_into: %w(chef_ingredient)
+      ) do |node|
+        node.set['chef-server-core']['version'] = :latest
+      end.converge(described_recipe)
+    end
+
+    it 'upgrades apt_package[chef-server]' do
+      expect(ubuntu_1404).to upgrade_apt_package('chef-server-core')
+    end
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/upgrade.rb
+++ b/test/fixtures/cookbooks/test/recipes/upgrade.rb
@@ -1,0 +1,3 @@
+chef_ingredient 'chef-server' do
+  action [:install, :upgrade]
+end


### PR DESCRIPTION
Move the install action content to new methods that return the right
resources etc so we can use those methods in an install or upgrade
action.

@chef-cookbooks/engineering-services @ryancragun 