### PR TITLE
Add push client test, fix naming for old packages

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -62,3 +62,9 @@ suites:
   - name: upgrade
     run_list:
       - recipe[test::upgrade]
+
+  - name: push_client
+    # we don't yet have push client packages for trusty, only precise
+    excludes: ['ubuntu-14.04']
+    run_list:
+      - recipe[test::push]

--- a/chefignore
+++ b/chefignore
@@ -6,3 +6,4 @@
 */spec
 */test
 */vendor
+.kitchen/*

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -168,11 +168,15 @@ module ChefIngredientCookbook
       elsif (product == 'manage') && (v < Mixlib::Versioning.parse('2.0.0'))
         data['package-name'] = 'opscode-manage'
         data['ctl-command'] = 'opscode-manage-ctl'
+      # TODO: When Chef Push server and client 2.0 are released, we
+      # need to implement similar logic to chef-server, so that the
+      # default "latest" version, 0.0.0 (no constraint) doesn't result
+      # in the old package.
       elsif (product == 'push-server') && (v < Mixlib::Versioning.parse('2.0.0'))
-        data['package-name'] = 'chef-push-server'
-        data['ctl-command'] = 'chef-push-ctl'
+        data['package-name'] = 'opscode-push-jobs-server'
+        data['ctl-command'] = 'opscode-push-jobs-server-ctl'
       elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('2.0.0'))
-        data['package-name'] = 'chef-push-client'
+        data['package-name'] = 'opscode-push-jobs-client'
       end
 
       data

--- a/spec/unit/recipes/test_push_spec.rb
+++ b/spec/unit/recipes/test_push_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe 'test::push' do
+  [{ platform: 'ubuntu', version: '14.04' },
+    { platform: 'centos', version: '6.5' }].each do |platform|
+    context "non-platform specific resources on #{platform[:platform]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform.merge(step_into: ['chef_ingredient'])
+        ).converge(described_recipe)
+      end
+
+      it 'installs the chef_ingredient[push-client]' do
+        expect(chef_run).to install_chef_ingredient('push-client')
+      end
+    end
+  end
+
+  context 'installs packages with yum on centos' do
+    cached(:centos_65) do
+      ChefSpec::SoloRunner.new(
+        platform: 'centos',
+        version: '6.5',
+        step_into: %w(chef_ingredient)
+      ) do |node|
+        node.set['test']['push-client']['version'] = :latest
+      end.converge(described_recipe)
+    end
+
+    it 'upgrades yum_package[push-client]' do
+      expect(centos_65).to install_yum_package('opscode-push-jobs-client')
+    end
+  end
+
+  context 'install packages with apt on ubuntu' do
+    cached(:ubuntu_1404) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04',
+        step_into: %w(chef_ingredient)
+      ) do |node|
+        node.set['test']['push-client']['version'] = :latest
+      end.converge(described_recipe)
+    end
+
+    it 'upgrades apt_package[push-client]' do
+      expect(ubuntu_1404).to install_apt_package('opscode-push-jobs-client')
+    end
+  end
+end

--- a/test/fixtures/cookbooks/test/attributes/default.rb
+++ b/test/fixtures/cookbooks/test/attributes/default.rb
@@ -1,3 +1,4 @@
+default['test']['push-client']['version'] = nil
 default['test']['chef-server-core']['version'] = nil
 default['test']['source_url'] = case node['platform_family']
                                 when 'debian'

--- a/test/fixtures/cookbooks/test/recipes/push.rb
+++ b/test/fixtures/cookbooks/test/recipes/push.rb
@@ -1,0 +1,4 @@
+chef_ingredient 'push-client' do
+  version node['test']['push-client']['version']
+  action :install
+end


### PR DESCRIPTION
Unfortunately we can't test this on Ubuntu 14.04 in kitchen as the
push client packages aren't pushed to the trusty distro on
packagecloud yet.

However, the specs work, and downstream users can add the repository
with "precise" as the codename instead of "trusty," so there's that.