### PR TITLE
Use recipe DSL to set the resource name.

### DIFF
--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -17,7 +17,7 @@
 class Chef
   class Resource
     class ChefIngredient < Chef::Resource::LWRPBase
-      self.resource_name = 'chef_ingredient'
+      resource_name :chef_ingredient
 
       actions :install, :uninstall, :remove, :reconfigure, :upgrade
       default_action :install

--- a/libraries/chef_server_ingredient_shim.rb
+++ b/libraries/chef_server_ingredient_shim.rb
@@ -28,7 +28,7 @@ end
 class Chef
   class Resource
     class ChefServerIngredient < Chef::Resource::ChefIngredient
-      self.resource_name = 'chef_server_ingredient'
+      resource_name :chef_server_ingredient
     end
   end
 end

--- a/libraries/ingredient_config_resource.rb
+++ b/libraries/ingredient_config_resource.rb
@@ -16,7 +16,7 @@
 class Chef
   class Resource
     class IngredientConfig < Chef::Resource::LWRPBase
-      self.resource_name = 'ingredient_config'
+      resource_name :ingredient_config
 
       actions :render
       default_action :render

--- a/libraries/omnibus_service_resource.rb
+++ b/libraries/omnibus_service_resource.rb
@@ -17,7 +17,7 @@
 class Chef
   class Resource
     class OmnibusService < Chef::Resource::LWRPBase
-      self.resource_name = 'omnibus_service'
+      resource_name :omnibus_service
 
       actions %i(start stop restart hup int kill graceful_kill once)
       default_action :nothing


### PR DESCRIPTION
Looks like `resource_name` setter has been in the DSL since Chef 12.0.0:

https://github.com/chef/chef/blob/12.0.0/lib/chef/resource/lwrp_base.rb#L61

I think we can safely switch to using these @jtimberman.

Fixes: https://github.com/chef-cookbooks/chef-ingredient/issues/16