### PR TITLE
ensure mixlib-versioning is installed for all actions

### DIFF
--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -48,18 +48,21 @@ class Chef
       end
 
       action :uninstall do
+        install_mixlib_versioning
         package ingredient_package_name do
           action :remove
         end
       end
 
       action :remove do
+        install_mixlib_versioning
         package ingredient_package_name do
           action :remove
         end
       end
 
       action :reconfigure do
+        install_mixlib_versioning
         add_config(new_resource.product_name, new_resource.config)
 
         execute "#{ingredient_package_name}-reconfigure" do


### PR DESCRIPTION
I have a cookbook where I'm currently only using the `:reconfigure` action.  I was getting a LoadError.
```
 LoadError
                             ---------
                             cannot load such file -- mixlib/versioning
```

This PR should allow the use of any of the actions even if `:install` or `:upgrade` are not previously called (since they install the gem)