### PR TITLE
Fixes #26, remove the ownership and permissions

### DIFF
--- a/libraries/ingredient_config_provider.rb
+++ b/libraries/ingredient_config_provider.rb
@@ -32,16 +32,11 @@ class Chef
         return if target_config.nil?
 
         directory ::File.dirname(target_config) do
-          owner 'root'
-          group 'root'
-          mode '0755'
           recursive true
           action :create
         end
 
         file target_config do
-          owner 'root'
-          group 'root'
           action :create
           sensitive new_resource.sensitive
           content get_config(new_resource.product_name)


### PR DESCRIPTION
Setting the owner and permissions on the config file's directory
conflicts with product ctl commands that also manage those
directories. For example some have the ownership set to opscode
instead of root, meaning this is updated every time and causes a
reconfigure to run again, extending the length of time it takes to
converge a node.