### PR TITLE
Fix rspec failures and warnings

### DIFF
--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -20,6 +20,7 @@ require_relative './helpers'
 class Chef
   class Provider
     class ChefIngredient < Chef::Provider::LWRPBase
+      provides :chef_ingredient
       # for include_recipe
       require 'chef/dsl/include_recipe'
       include Chef::DSL::IncludeRecipe

--- a/libraries/chef_server_ingredient_shim.rb
+++ b/libraries/chef_server_ingredient_shim.rb
@@ -21,6 +21,7 @@
 class Chef
   class Provider
     class ChefServerIngredient < Chef::Provider::ChefIngredient
+      provides :chef_server_ingredient
     end
   end
 end

--- a/libraries/ingredient_config_provider.rb
+++ b/libraries/ingredient_config_provider.rb
@@ -19,6 +19,7 @@ require_relative './helpers'
 class Chef
   class Provider
     class IngredientConfig < Chef::Provider::LWRPBase
+      provides :ingredient_config
       include ChefIngredientCookbook::Helpers
 
       use_inline_resources

--- a/libraries/omnibus_service_provider.rb
+++ b/libraries/omnibus_service_provider.rb
@@ -20,6 +20,7 @@ require_relative './helpers'
 class Chef
   class Provider
     class OmnibusService < Chef::Provider::LWRPBase
+      provides :omnibus_service
       # Methods for use in resources, found in helpers.rb
       include ChefIngredientCookbook::Helpers
 

--- a/spec/unit/recipes/test_push_spec.rb
+++ b/spec/unit/recipes/test_push_spec.rb
@@ -27,8 +27,15 @@ describe 'test::push' do
       end.converge(described_recipe)
     end
 
+    it 'creates the yum repository'do
+      expect(centos_65).to create_yum_repository('chef-stable')
+    end
+
     it 'upgrades yum_package[push-client]' do
-      expect(centos_65).to install_yum_package('opscode-push-jobs-client')
+      pkgres = centos_65.find_resource('package', 'push-client')
+      expect(pkgres).to_not be_nil
+      expect(pkgres).to be_a(Chef::Resource::YumPackage)
+      expect(centos_65).to install_package('push-client')
     end
   end
 
@@ -43,8 +50,15 @@ describe 'test::push' do
       end.converge(described_recipe)
     end
 
+    it 'creates the apt repository' do
+      expect(ubuntu_1404).to add_apt_repository('chef-stable')
+    end
+
     it 'upgrades apt_package[push-client]' do
-      expect(ubuntu_1404).to install_apt_package('opscode-push-jobs-client')
+      pkgres = ubuntu_1404.find_resource('package', 'push-client')
+      expect(pkgres).to_not be_nil
+      expect(pkgres).to be_a(Chef::Resource::AptPackage)
+      expect(ubuntu_1404).to install_package('push-client')
     end
   end
 end

--- a/spec/unit/recipes/test_repo_spec.rb
+++ b/spec/unit/recipes/test_repo_spec.rb
@@ -79,12 +79,22 @@ EOS
       end.converge(described_recipe)
     end
 
+    it 'creates the yum repository' do
+      expect(centos_65).to create_yum_repository('chef-stable')
+    end
+
     it 'installs yum_package[chef-server]' do
-      expect(centos_65).to install_yum_package('chef-server-core')
+      pkgres = centos_65.find_resource('package', 'chef-server')
+      expect(pkgres).to_not be_nil
+      expect(pkgres).to be_a(Chef::Resource::YumPackage)
+      expect(centos_65).to install_package('chef-server')
     end
 
     it 'installs yum_package[opscode-manage]' do
-      expect(centos_65).to install_yum_package('opscode-manage')
+      pkgres = centos_65.find_resource('package', 'manage')
+      expect(pkgres).to_not be_nil
+      expect(pkgres).to be_a(Chef::Resource::YumPackage)
+      expect(centos_65).to install_package('manage')
     end
   end
 
@@ -100,7 +110,7 @@ EOS
     end
 
     it 'installs the package with the release version string and el6' do
-      expect(centos_65).to install_yum_package('chef-server-core').with(
+      expect(centos_65).to install_package('chef-server-core').with(
         version: '12.0.4-1.el6'
       )
     end
@@ -118,7 +128,7 @@ EOS
     end
 
     it 'installs the package with the release version string and el6' do
-      expect(centos_65).to install_yum_package('chef-server-core').with(
+      expect(centos_65).to install_package('chef-server-core').with(
         version: '12.0.4-1.el6'
       )
     end
@@ -136,7 +146,7 @@ EOS
     end
 
     it 'installs the package with the tilde version separator and release identifier and el6' do
-      expect(centos_65).to install_yum_package('chef-server-core').with(
+      expect(centos_65).to install_package('chef-server-core').with(
         version: '12.1.0~rc.3-1.el6'
       )
     end
@@ -154,7 +164,7 @@ EOS
     end
 
     it 'installs yum_package[chef-server]' do
-      expect(centos_65).to install_yum_package('chef-server-core')
+      expect(centos_65).to install_package('chef-server-core')
     end
   end
 
@@ -170,7 +180,7 @@ EOS
     end
 
     it 'installs yum_package[chef-server]' do
-      expect(centos_65).to install_yum_package('chef-server-core')
+      expect(centos_65).to install_package('chef-server-core')
     end
   end
 
@@ -186,11 +196,17 @@ EOS
     end
 
     it 'installs apt_package[chef-server-core]' do
-      expect(ubuntu_1404).to install_apt_package('chef-server-core')
+      pkgres = ubuntu_1404.find_resource('package', 'chef-server')
+      expect(pkgres).to_not be_nil
+      expect(pkgres).to be_a(Chef::Resource::AptPackage)
+      expect(ubuntu_1404).to install_package('chef-server')
     end
 
     it 'installs apt_package[opscode-manage]' do
-      expect(ubuntu_1404).to install_apt_package('opscode-manage')
+      pkgres = ubuntu_1404.find_resource('package', 'manage')
+      expect(pkgres).to_not be_nil
+      expect(pkgres).to be_a(Chef::Resource::AptPackage)
+      expect(ubuntu_1404).to install_package('manage')
     end
   end
 
@@ -206,7 +222,7 @@ EOS
     end
 
     it 'installs the package with the release version string' do
-      expect(ubuntu_1404).to install_apt_package('chef-server-core').with(
+      expect(ubuntu_1404).to install_package('chef-server-core').with(
         version: '12.0.4-1'
       )
     end
@@ -224,7 +240,7 @@ EOS
     end
 
     it 'installs the package with the release version string' do
-      expect(ubuntu_1404).to install_apt_package('chef-server-core').with(
+      expect(ubuntu_1404).to install_package('chef-server-core').with(
         version: '12.0.4-1'
       )
     end
@@ -242,7 +258,7 @@ EOS
     end
 
     it 'installs the package with the tilde version separator' do
-      expect(ubuntu_1404).to install_apt_package('chef-server-core').with(
+      expect(ubuntu_1404).to install_package('chef-server-core').with(
         version: '12.1.0~rc.3-1'
       )
     end
@@ -260,7 +276,7 @@ EOS
     end
 
     it 'installs yum_package[chef-server]' do
-      expect(ubuntu_1404).to install_apt_package('chef-server-core')
+      expect(ubuntu_1404).to install_package('chef-server-core')
     end
   end
 
@@ -276,7 +292,7 @@ EOS
     end
 
     it 'installs apt_package[chef-server]' do
-      expect(ubuntu_1404).to install_apt_package('chef-server-core')
+      expect(ubuntu_1404).to install_package('chef-server-core')
     end
   end
 end

--- a/spec/unit/recipes/test_upgrade_spec.rb
+++ b/spec/unit/recipes/test_upgrade_spec.rb
@@ -28,7 +28,7 @@ describe 'test::upgrade' do
     end
 
     it 'upgrades yum_package[chef-server]' do
-      expect(centos_65).to upgrade_yum_package('chef-server-core')
+      expect(centos_65).to upgrade_package('chef-server-core')
     end
   end
 
@@ -44,7 +44,7 @@ describe 'test::upgrade' do
     end
 
     it 'upgrades apt_package[chef-server]' do
-      expect(ubuntu_1404).to upgrade_apt_package('chef-server-core')
+      expect(ubuntu_1404).to upgrade_package('chef-server-core')
     end
   end
 end


### PR DESCRIPTION
Add provides in providers to get rid of noisy warnings

Test that we're getting the right provider (yum or apt) for the
different platforms by using ChefSpec's runner lookup method
`#find_resource`. We want to ensure that the returned resource is not
nil, uses the correct resource class, and finally that it's a package
resource with an install action.