### PR TITLE
Correct supermarket config file in product_matrix

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -193,7 +193,7 @@ module ChefIngredientCookbook
         'supermarket' => {
           'package-name' => 'supermarket',
           'ctl-command'  => 'supermarket-ctl',
-          'config-file'  => '/etc/supermarket/supermarket.rb'
+          'config-file'  => '/etc/supermarket/supermarket.json'
         }
       }
     end


### PR DESCRIPTION
As a user I would like to use `chef_ingredient` and setup my supermarket server passing my configuration through the `config` attribute so I don't have to use other methods like a `template` or `file` resources to lay down my configuration.

**Solution**

This commit modified the `product_matrix` pointing to the right `config-file` for supermarket that is `/etc/supermarket/supermarket.json` 

Closes https://github.com/chef-cookbooks/chef-ingredient/issues/30