### PR TITLE
Fix syntax error in omnibus_service_provider

### DIFF
--- a/libraries/omnibus_service_provider.rb
+++ b/libraries/omnibus_service_provider.rb
@@ -30,8 +30,8 @@ class Chef
         true
       end
 
-      %i(start stop restart hup int kill graceful-kill once).each do |sv_command|
-        action sv_command do
+      %w(start stop restart hup int kill graceful-kill once).each do |sv_command|
+        action sv_command.tr('-', '_').to_sym do
           execute "#{omnibus_ctl_command} #{sv_command} #{omnibus_service_name.last}"
         end
       end


### PR DESCRIPTION
Fixes a syntax error
```
================================================================================
Recipe Compile Error in /opt/chef-marketplace/embedded/cookbooks/chef-ingredient/libraries/omnibus_service_provider.rb
================================================================================

SyntaxError
-----------
/opt/opscode/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.0.current.0/lib/chef/provider.rb:282: syntax error, unexpected '-', expecting ';' or '\n'
            def action_graceful-kill
                                ^
/opt/opscode/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.0.current.0/lib/chef/provider.rb:286: syntax error, unexpected keyword_ensure, expecting end-of-input

Cookbook Trace:
---------------
  /opt/chef-marketplace/embedded/cookbooks/chef-ingredient/libraries/omnibus_service_provider.rb:34:in `block in <class:OmnibusService>'
  /opt/chef-marketplace/embedded/cookbooks/chef-ingredient/libraries/omnibus_service_provider.rb:33:in `each'
  /opt/chef-marketplace/embedded/cookbooks/chef-ingredient/libraries/omnibus_service_provider.rb:33:in `<class:OmnibusService>'
  /opt/chef-marketplace/embedded/cookbooks/chef-ingredient/libraries/omnibus_service_provider.rb:22:in `<class:Provider>'
  /opt/chef-marketplace/embedded/cookbooks/chef-ingredient/libraries/omnibus_service_provider.rb:21:in `<class:Chef>'
  /opt/chef-marketplace/embedded/cookbooks/chef-ingredient/libraries/omnibus_service_provider.rb:20:in `<top (required)>'
```