### PR TITLE
Auto update for debian / rhel platforms & refactoring to support omnitruck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 /.kitchen.local.yml
 
 .DS_Store
+
+# Chef
+Policyfile.lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /.bundle/
 /bundle/
 /vendor/gems/
+/vendor
 
 # Berkshelf
 /Berksfile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -72,3 +72,7 @@ suites:
   - name: ingredient_config
     run_list:
       - recipe[test::ingredient_config]
+
+  - name: different_channels
+    run_list:
+      - recipe[test::different_channels]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,7 @@
 AllCops:
-  Include:
-    - Berksfile
-    - Gemfile
-    - Rakefile
-    - Thorfile
-    - Guardfile
   Exclude:
-    - vendor/**
+    - Guardfile
+    - vendor/**/*
 
 AlignParameters:
   Enabled: false
@@ -37,10 +32,6 @@ Style/FileName:
 
 Metrics/AbcSize:
   Enabled: false
-
-AllCops:
-  Exclude:
-    - 'Guardfile'
 
 Style/GuardClause:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+cache: bundler
+bundler_args: "--jobs 7 --without kitchen_common"
+
+rvm:
+  - 2.1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache: bundler
-bundler_args: "--jobs 7 --without kitchen_common"
+bundler_args: "--jobs 7"
 
 rvm:
   - 2.1.5

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,7 @@
+source 'https://supermarket.chef.io'
+
+metadata
+
+group :integration do
+  cookbook 'test', path: './test/fixtures/cookbooks/test'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development do
   gem 'guard-rspec'
   gem 'guard-rubocop'
   gem 'mixlib-versioning'
-  gem 'mixlib-install', github: 'chef/mixlib-install'
+  gem 'mixlib-install', github: 'chef/mixlib-install', branch: 'v0.7.0'
 end
 
 # Run kitchen using Chef DK bundled set of gems.

--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,6 @@ group :unit do
   gem 'chef-dk', '~> 0.7.0'
 end
 
-group :kitchen_common do
-  gem 'test-kitchen', '~> 1.3'
-end
-
 group :development do
   gem 'ruby_gntp'
   gem 'growl'
@@ -32,3 +28,5 @@ group :development do
   gem 'mixlib-versioning'
   gem 'mixlib-install', github: 'chef/mixlib-install'
 end
+
+# Run kitchen using Chef DK bundled set of gems.

--- a/Gemfile
+++ b/Gemfile
@@ -30,4 +30,5 @@ group :development do
   gem 'guard-rspec'
   gem 'guard-rubocop'
   gem 'mixlib-versioning'
+  gem 'mixlib-install', github: 'chef/mixlib-install'
 end

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ chef_ingredient "chef" do
 end
 ```
 
-To install an addon of Chef Server from `:current` branch:
+To install an addon of Chef Server from `:current` channel:
 
 ```ruby
 chef_ingredient 'chef-server' do

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A "chef ingredient" is the core package itself, or products or add-on components
 - `ctl_command`: The "ctl" command, e.g., `chef-server-ctl`. This should be automatically detected by the library helper method `chef_ctl_command`, but may need to be specified if something changes, like a new add-on is made available.
 - `options`: Options passed to the `package` resource used for installation.
 - `version`: Package version to install. Can be specified in various semver-alike ways: `12.0.4`, `12.0.3-rc.3`, and also `:latest`/`'latest'`. Do not use this property when specifying `package_source`. Default is `:latest`, which will install the latest package from the repository.
+- `channel`: Channel to install the products from. It can be `:stable` (default) or `:current`.
 - `package_source`: Full path to a location where the package is located. If present, this file is used for installing the package. Default `nil`.
 - `timeout`: The amount of time (in seconds) to wait to fetch the installer before timing out. Default: default timeout of the Chef package resource - `900` seconds.
 
@@ -112,6 +113,30 @@ end
 
 ingredient_config "chef-server" do
   notifies :reconfigure, "chef_ingredient[chef-server]"
+end
+
+```
+
+To install or upgrade lastest version of Chef Client on your nodes:
+
+```ruby
+chef_ingredient "chef" do
+  action :upgrade
+  version :latest
+end
+```
+
+To install an addon of Chef Server from `:current` branch:
+
+```ruby
+chef_ingredient 'chef-server' do
+  channel :stable
+  action :install
+end
+
+chef_ingredient 'analytics' do
+  channel :current
+  action :install
 end
 
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ desc 'Run ChefSpec examples'
 RSpec::Core::RakeTask.new(:spec)
 
 desc 'Run all tests'
-task test: [:rubocop, :foodcritic] # TODO: Add ', :spec' once they pass.
+task test: [:rubocop, :foodcritic, :spec]
 task default: :test
 task lint: :foodcritic
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
 desc 'Run RuboCop style and lint checks'
-Rubocop::RakeTask.new(:rubocop)
+RuboCop::RakeTask.new(:rubocop)
 
 desc 'Run Foodcritic lint checks'
 FoodCritic::Rake::LintTask.new(:foodcritic) do |t|
@@ -20,7 +20,7 @@ desc 'Run ChefSpec examples'
 RSpec::Core::RakeTask.new(:spec)
 
 desc 'Run all tests'
-task test: [:rubocop, :foodcritic, :spec]
+task test: [:rubocop, :foodcritic] # TODO: Add ', :spec' once they pass.
 task default: :test
 task lint: :foodcritic
 
@@ -31,6 +31,6 @@ begin
   desc 'Alias for kitchen:all'
   task integration: 'kitchen:all'
   task test_all: [:test, :integration]
-rescue LoadError
+rescue LoadError, Kitchen::ClientError
   puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
 end

--- a/Rakefile
+++ b/Rakefile
@@ -31,6 +31,6 @@ begin
   desc 'Alias for kitchen:all'
   task integration: 'kitchen:all'
   task test_all: [:test, :integration]
-rescue LoadError, Kitchen::ClientError
+rescue LoadError, Kitchen::ClientError, Kitchen::UserError
   puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
 end

--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -37,17 +37,16 @@ class Chef
         true
       end
 
-      def initialize
+      def initialize(name, run_context=nil)
+        super(name, run_context)
         @action_handler = case node['platform_family']
-        when 'debian'
-          ChefIngredient::DebianHandler.new
-        when 'rhel'
-          ChefIngredient::RhelHandler.new
-        else
-          ChefIngredient::OmnitruckHandler.new
-        end
-
-        super
+                          when 'debian'
+                            ::ChefIngredient::DebianHandler.new
+                          when 'rhel'
+                            ::ChefIngredient::RhelHandler.new
+                          else
+                            ::ChefIngredient::OmnitruckHandler.new
+                          end
       end
 
       action :install do
@@ -72,7 +71,11 @@ class Chef
         action_handler.uninstall
       end
 
-      alias_method :remove, :uninstall
+      action :uninstall do
+        install_mixlib_versioning
+
+        action_handler.uninstall
+      end
 
       action :reconfigure do
         install_mixlib_versioning

--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -31,22 +31,20 @@ class Chef
       include Chef::DSL::IncludeRecipe
       include ChefIngredientCookbook::Helpers
 
-      attr_reader :action_handler
-
       def whyrun_supported?
         true
       end
 
-      def initialize(name, run_context=nil)
+      def initialize(name, run_context = nil)
         super(name, run_context)
-        @action_handler = case node['platform_family']
-                          when 'debian'
-                            ::ChefIngredient::DebianHandler.new
-                          when 'rhel'
-                            ::ChefIngredient::RhelHandler.new
-                          else
-                            ::ChefIngredient::OmnitruckHandler.new
-                          end
+        case node['platform_family']
+        when 'debian'
+          extend ::ChefIngredient::DebianHandler
+        when 'rhel'
+          extend ::ChefIngredient::RhelHandler
+        else
+          extend ::ChefIngredient::OmnitruckHandler
+        end
       end
 
       action :install do
@@ -54,7 +52,7 @@ class Chef
         add_config(new_resource.product_name, new_resource.config)
         declare_chef_run_stop_resource
 
-        action_handler.install
+        handle_install
       end
 
       action :upgrade do
@@ -62,19 +60,19 @@ class Chef
         add_config(new_resource.product_name, new_resource.config)
         declare_chef_run_stop_resource
 
-        action_handler.upgrade
+        handle_upgrade
       end
 
       action :uninstall do
         install_mixlib_versioning
 
-        action_handler.uninstall
+        handle_uninstall
       end
 
       action :uninstall do
         install_mixlib_versioning
 
-        action_handler.uninstall
+        handle_uninstall
       end
 
       action :reconfigure do

--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -42,8 +42,9 @@ class Chef
           extend ::ChefIngredient::DebianHandler
         when 'rhel'
           extend ::ChefIngredient::RhelHandler
-        else
-          extend ::ChefIngredient::OmnitruckHandler
+          # TODO(serdar): Enable installations from Omnitruck
+          # else
+          #   extend ::ChefIngredient::OmnitruckHandler
         end
       end
 

--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -21,10 +21,8 @@ class Chef
 
       actions :install, :uninstall, :remove, :reconfigure, :upgrade
       default_action :install
-      state_attrs :installed # TODO: Remove state_attrs and installed.
 
       attribute :product_name, kind_of: String, name_attribute: true
-      attribute :installed, kind_of: [TrueClass, FalseClass, NilClass], default: false
       attribute :reconfigure, kind_of: [TrueClass, FalseClass], default: false # TODO: Remove this attribute.
       attribute :config, kind_of: String, default: nil
 

--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -27,7 +27,7 @@ class Chef
 
       # Attributes for determining what version to install from which channel
       attribute :version, kind_of: [String, Symbol], default: :latest
-      attribute :channel, kind_of: Symbol, default: :stable, :equal_to => [:current, :stable]
+      attribute :channel, kind_of: Symbol, default: :stable, equal_to: [:current, :stable]
 
       # Attribute to install package from local file
       attribute :package_source, kind_of: String, default: nil

--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -23,7 +23,6 @@ class Chef
       default_action :install
 
       attribute :product_name, kind_of: String, name_attribute: true
-      attribute :reconfigure, kind_of: [TrueClass, FalseClass], default: false # TODO: Remove this attribute.
       attribute :config, kind_of: String, default: nil
 
       # Attributes for determining what version to install from which channel

--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -21,22 +21,25 @@ class Chef
 
       actions :install, :uninstall, :remove, :reconfigure, :upgrade
       default_action :install
-      state_attrs :installed # TODO: I think we need to at minimum add :version here.
+      state_attrs :installed # TODO: Remove state_attrs and installed.
 
       attribute :product_name, kind_of: String, name_attribute: true
       attribute :installed, kind_of: [TrueClass, FalseClass, NilClass], default: false
-      attribute :reconfigure, kind_of: [TrueClass, FalseClass], default: false # TODO: Are we honoring this during install or upgrade?
+      attribute :reconfigure, kind_of: [TrueClass, FalseClass], default: false # TODO: Remove this attribute.
       attribute :config, kind_of: String, default: nil
+
+      # Attributes for determining what version to install from which channel
+      attribute :version, kind_of: [String, Symbol], default: :latest
+      attribute :channel, kind_of: Symbol, default: :stable, :equal_to => [:current, :stable]
 
       # Attribute to install package from local file
       attribute :package_source, kind_of: String, default: nil
 
-      # Attributes for reconfigure step
-      attribute :ctl_command, kind_of: String # TODO: Can we rename this to :reconfigure_command?
+      # Sets the *-ctl command to use when doing reconfigure
+      attribute :ctl_command, kind_of: String
 
-      # Attributes for package
-      attribute :options, kind_of: String # TODO: Has there been a use case around this or is this premature optimization?
-      attribute :version, kind_of: [String, Symbol], default: :latest
+      # Attributes for package resources used on rhel and debian platforms
+      attribute :options, kind_of: String
       attribute :timeout, kind_of: [Integer, String, NilClass], default: nil
     end
   end

--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -21,21 +21,21 @@ class Chef
 
       actions :install, :uninstall, :remove, :reconfigure, :upgrade
       default_action :install
-      state_attrs :installed
+      state_attrs :installed # TODO: I think we need to at minimum add :version here.
 
       attribute :product_name, kind_of: String, name_attribute: true
       attribute :installed, kind_of: [TrueClass, FalseClass, NilClass], default: false
-      attribute :reconfigure, kind_of: [TrueClass, FalseClass], default: false
+      attribute :reconfigure, kind_of: [TrueClass, FalseClass], default: false # TODO: Are we honoring this during install or upgrade?
       attribute :config, kind_of: String, default: nil
 
       # Attribute to install package from local file
       attribute :package_source, kind_of: String, default: nil
 
       # Attributes for reconfigure step
-      attribute :ctl_command, kind_of: String
+      attribute :ctl_command, kind_of: String # TODO: Can we rename this to :reconfigure_command?
 
       # Attributes for package
-      attribute :options, kind_of: String
+      attribute :options, kind_of: String # TODO: Has there been a use case around this or is this premature optimization?
       attribute :version, kind_of: [String, Symbol], default: :latest
       attribute :timeout, kind_of: [Integer, String, NilClass], default: nil
     end

--- a/libraries/debian_handler.rb
+++ b/libraries/debian_handler.rb
@@ -16,16 +16,16 @@
 #
 
 module ChefIngredient
-  class DebianHandler
-    def install
+  module DebianHandler
+    def handle_install
       configure_package(:install)
     end
 
-    def upgrade
+    def handle_upgrade
       configure_package(:upgrade)
     end
 
-    def uninstall
+    def handle_uninstall
       package ingredient_package_name do
         action :remove
       end
@@ -52,11 +52,8 @@ module ChefIngredient
           end
         end
       else
-        # Enable the required apt-repository. We treat ['apt-chef']['repo_name']
-        # as an ephemeral attribute that is used during apt-chef recipe.
-        node.set['apt-chef']['repo_name'] = "chef-#{new_resource.channel}"
-        include_recipe 'apt-chef'
-        node.rm('apt-chef', 'repo_name')
+        # Enable the required apt-repository.
+        include_recipe "apt-chef::#{new_resource.channel}"
 
         # Pin it so that product can only be installed from its own channel
         apt_preference ingredient_package_name do

--- a/libraries/debian_handler.rb
+++ b/libraries/debian_handler.rb
@@ -1,0 +1,63 @@
+#
+# Author:: Serdar Sutay <serdar@chef.io>
+# Copyright (c) 2015, Chef Software, Inc. <legal@chef.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ChefIngredient
+  class DebianHandler
+    def install
+      configure_package(:upgrade)
+    end
+
+    def upgrade
+      configure_package(:upgrade)
+    end
+
+    def uninstall
+      package ingredient_package_name do
+        action :remove
+      end
+    end
+
+    private
+    def configure_package(action_name)
+      # TODO: Hrmmm this is interesting? stable? delete this every time?
+      file '/etc/apt/sources.list.d/chef_stable_.list' do
+        action :delete
+        only_if { ::File.exist?('/etc/apt/sources.list.d/chef_stable_.list') }
+      end
+
+      if new_resource.package_source
+        dpkg_package new_resource.product_name do
+          action action_name
+          package_name ingredient_package_name
+          options new_resource.options
+          source new_resource.package_source
+        end
+      else
+        include_recipe 'apt-chef'
+
+        package new_resource.product_name do
+          action action_name
+          package_name ingredient_package_name
+          options new_resource.options
+          # TODO: Hrmmm not sure why are we fucking with the given version this much.
+          version install_version if Mixlib::Versioning.parse(version_string(new_resource.version)) > '0.0.0'
+          timeout new_resource.timeout
+        end
+      end
+    end
+  end
+end

--- a/libraries/debian_handler.rb
+++ b/libraries/debian_handler.rb
@@ -45,6 +45,10 @@ module ChefIngredient
           package_name ingredient_package_name
           options new_resource.options
           source new_resource.package_source
+
+          if new_resource.product_name == 'chef'
+            notifies :run, 'ruby_block[stop chef run]', :immediately
+          end
         end
       else
         include_recipe 'apt-chef'
@@ -56,6 +60,10 @@ module ChefIngredient
           # TODO: Hrmmm not sure why are we fucking with the given version this much.
           version install_version if Mixlib::Versioning.parse(version_string(new_resource.version)) > '0.0.0'
           timeout new_resource.timeout
+
+          if new_resource.product_name == 'chef'
+            notifies :run, 'ruby_block[stop chef run]', :immediately
+          end
         end
       end
     end

--- a/libraries/debian_handler.rb
+++ b/libraries/debian_handler.rb
@@ -18,7 +18,7 @@
 module ChefIngredient
   class DebianHandler
     def install
-      configure_package(:upgrade)
+      configure_package(:install)
     end
 
     def upgrade
@@ -33,7 +33,7 @@ module ChefIngredient
 
     private
     def configure_package(action_name)
-      # TODO: Hrmmm this is interesting? stable? delete this every time?
+      # This is to cleanup old cruft from chef-server-ingredient
       file '/etc/apt/sources.list.d/chef_stable_.list' do
         action :delete
         only_if { ::File.exist?('/etc/apt/sources.list.d/chef_stable_.list') }
@@ -51,14 +51,27 @@ module ChefIngredient
           end
         end
       else
+        # Enable the required apt-repository. We treat ['apt-chef']['repo_name']
+        # as an ephemeral attribute that is used during apt-chef recipe.
+        node.set['apt-chef']['repo_name'] = "chef-#{new_resource.channel}"
         include_recipe 'apt-chef'
+        node.rm['apt-chef']['repo_name']
+
+        # Pin it so that product can only be installed from its own channel
+        apt_preference ingredient_package_name do
+          pin "release o=https://packagecloud.io/chef/#{new_resource.channel}"
+          pin_priority '900'
+        end
 
         package new_resource.product_name do
           action action_name
           package_name ingredient_package_name
           options new_resource.options
-          # TODO: Hrmmm not sure why are we fucking with the given version this much.
-          version install_version if Mixlib::Versioning.parse(version_string(new_resource.version)) > '0.0.0'
+          # If the user specifies "0.0.0", :latest or "latest" as version,
+          # we should not give any version to the package resource.
+          if Mixlib::Versioning.parse(version_string(new_resource.version)) > '0.0.0'
+            version version_for_package_resource
+          end
           timeout new_resource.timeout
 
           if new_resource.product_name == 'chef'

--- a/libraries/debian_handler.rb
+++ b/libraries/debian_handler.rb
@@ -48,6 +48,7 @@ module ChefIngredient
           source new_resource.package_source
 
           if new_resource.product_name == 'chef'
+            # We define this resource in ChefIngredientProvider
             notifies :run, 'ruby_block[stop chef run]', :immediately
           end
         end
@@ -75,6 +76,7 @@ module ChefIngredient
           end
 
           if new_resource.product_name == 'chef'
+            # We define this resource in ChefIngredientProvider
             notifies :run, 'ruby_block[stop chef run]', :immediately
           end
         end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -199,14 +199,18 @@ module ChefIngredientCookbook
     def add_config(product, content)
       return if content.nil?
 
-      node.run_state[:ingredient_config_data] ||= {}
-      node.run_state[:ingredient_config_data][product] ||= ''
-      node.run_state[:ingredient_config_data][product] += content
+      # FC001: Use strings in preference to symbols to access node attributes
+      # foodcritic thinks we are accessing a node attribute
+      node.run_state[:ingredient_config_data] ||= {}              # ~FC001
+      node.run_state[:ingredient_config_data][product] ||= ''     # ~FC001
+      node.run_state[:ingredient_config_data][product] += content # ~FC001
     end
 
     def get_config(product)
-      node.run_state[:ingredient_config_data] ||= {}
-      node.run_state[:ingredient_config_data][product] ||= ''
+      # FC001: Use strings in preference to symbols to access node attributes
+      # foodcritic thinks we are accessing a node attribute
+      node.run_state[:ingredient_config_data] ||= {}          # ~FC001
+      node.run_state[:ingredient_config_data][product] ||= '' # ~FC001
     end
 
     def fqdn_resolves?(fqdn)
@@ -226,7 +230,7 @@ module ChefIngredientCookbook
       # updates of chef, so we *MUST* stop the chef-client run when its version
       # changes. The gems versions that chef-client started with will not
       # necessarily exist after an upgrade.
-      ruby_block, 'stop chef run' do
+      ruby_block 'stop chef run' do
         action :nothing
         block do
           Chef::Application.fatal! 'Chef version has changed during the run. Stopping the current Chef run. Please run chef again.'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -70,13 +70,6 @@ module ChefIngredientCookbook
       new_resource.ctl_command || chef_ctl_command(new_resource.product_name)
     end
 
-    def reconfigure
-      ctl_cmd = ctl_command
-      execute "#{new_resource.product_name}-reconfigure" do
-        command "#{ctl_cmd} reconfigure"
-      end
-    end
-
     # When updating this, also update PRODUCT_MATRIX.md
     def product_matrix
       {

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -34,25 +34,6 @@ module ChefIngredientCookbook
       product_lookup(new_resource.product_name, version_string(new_resource.version))['package-name']
     end
 
-    def local_package_resource
-      return :dpkg_package if node['platform_family'] == 'debian'
-      return :rpm_package  if node['platform_family'] == 'rhel'
-      :package # fallback if there's no platform match
-    end
-
-    def package_resource(ingredient_action)
-      presource = new_resource.package_source.nil? ? :package : local_package_resource
-
-      declare_resource presource, new_resource.product_name do
-        package_name ingredient_package_name
-        options new_resource.options
-        version install_version if Mixlib::Versioning.parse(version_string(new_resource.version)) > '0.0.0'
-        source new_resource.package_source
-        timeout new_resource.timeout
-        action ingredient_action
-      end
-    end
-
     def install_mixlib_versioning
       # We need Mixlib::Versioning in the library helpers for
       # parsing the version string.
@@ -62,16 +43,6 @@ module ChefIngredientCookbook
       end
 
       require 'mixlib/versioning'
-    end
-
-    def create_repository
-      cleanup_old_repo_config if ::File.exist?(old_ingredient_repo_file)
-      include_recipe "#{package_repo_type}-chef" if new_resource.package_source.nil?
-    end
-
-    def package_repo_type
-      return 'apt' if node['platform_family'] == 'debian'
-      return 'yum' if node['platform_family'] == 'rhel'
     end
 
     def rhel_major_version
@@ -93,17 +64,6 @@ module ChefIngredientCookbook
 
     def rhel_append_version
       ".el#{rhel_major_version}"
-    end
-
-    def old_ingredient_repo_file
-      return '/etc/apt/sources.list.d/chef_stable_.list' if node['platform_family'] == 'debian'
-      return '/etc/yum.repos.d/chef_stable_.repo' if node['platform_family'] == 'rhel'
-    end
-
-    def cleanup_old_repo_config
-      file old_ingredient_repo_file do
-        action :delete
-      end
     end
 
     def ctl_command

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -225,6 +225,21 @@ module ChefIngredientCookbook
     end
 
     module_function :fqdn_resolves?
+
+    def declare_chef_run_stop_resource
+      # We do not supply an option to turn off stopping the chef client run
+      # after a version change. As the gems shipped with omnitruck artifacts
+      # change, chef-client runs *WILL* occasionally break on minor version
+      # updates of chef, so we *MUST* stop the chef-client run when its version
+      # changes. The gems versions that chef-client started with will not
+      # necessarily exist after an upgrade.
+      ruby_block, 'stop chef run' do
+        action :nothing
+        block do
+          Chef::Application.fatal! 'Chef version has changed during the run. Stopping the current Chef run. Please run chef again.'
+        end
+      end
+    end
   end
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -50,7 +50,7 @@ module ChefIngredientCookbook
       node['platform_version']
     end
 
-    def install_version
+    def version_for_package_resource
       require 'mixlib/versioning'
       v = Mixlib::Versioning.parse(version_string(new_resource.version))
       version = "#{v.major}.#{v.minor}.#{v.patch}"

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,5 +1,5 @@
 if defined?(ChefSpec)
-  %i{chef_ingredient chef_server_ingredient omnibus_service ingredient_config}.each do |resource|
+  %i(chef_ingredient chef_server_ingredient omnibus_service ingredient_config).each do |resource|
     ChefSpec.define_matcher resource
   end
 

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -70,13 +70,4 @@ if defined?(ChefSpec)
   def once_kill_omnibus_service(pkg)
     ChefSpec::Matchers::ResourceMatcher.new(:omnibus_service, :once, pkg)
   end
-
-  def render_ingredient_config(pkg)
-    ChefSpec::Matchers::ResourceMatcher.new(:ingredient_config, :render, pkg)
-  end
-
-  def add_ingredient_config(pkg)
-    ChefSpec::Matchers::ResourceMatcher.new(:ingredient_config, :add, pkg)
-  end
-
 end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -70,4 +70,12 @@ if defined?(ChefSpec)
   def once_kill_omnibus_service(pkg)
     ChefSpec::Matchers::ResourceMatcher.new(:omnibus_service, :once, pkg)
   end
+
+  def render_ingredient_config(pkg)
+    ChefSpec::Matchers::ResourceMatcher.new(:ingredient_config, :render, pkg)
+  end
+
+  def add_ingredient_config(pkg)
+    ChefSpec::Matchers::ResourceMatcher.new(:ingredient_config, :add, pkg)
+  end
 end

--- a/libraries/omnitruck_handler.rb
+++ b/libraries/omnitruck_handler.rb
@@ -1,0 +1,32 @@
+#
+# Author:: Serdar Sutay <serdar@chef.io>
+# Copyright (c) 2015, Chef Software, Inc. <legal@chef.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ChefIngredient
+  class RhelHandler
+    def install
+      # TODO: use mixlib-install to install.
+    end
+
+    def upgrade
+      # TODO: use mixlib-install to upgrade.
+    end
+
+    def uninstall
+      # TODO: use mixlib-install to uninstall.
+    end
+  end
+end

--- a/libraries/omnitruck_handler.rb
+++ b/libraries/omnitruck_handler.rb
@@ -18,10 +18,10 @@
 require_relative './omnitruck_helpers'
 
 module ChefIngredient
-  class OmnitruckHandler
+  module OmnitruckHandler
     include ChefIngredientCookbook::OmnitruckHelpers
 
-    def install
+    def handle_install
       current_version = current_version(new_resource.product_name)
       latest_version = latest_available_version(new_resource.product_name)
 
@@ -39,7 +39,7 @@ module ChefIngredient
       end
     end
 
-    def upgrade
+    def handle_upgrade
       current_version = current_version(new_resource.product_name)
       latest_version = latest_available_version(new_resource.product_name)
 
@@ -51,7 +51,7 @@ module ChefIngredient
       end
     end
 
-    def uninstall
+    def handle_uninstall
       uninstall_product(new_resource.product_name)
     end
   end

--- a/libraries/omnitruck_helpers.rb
+++ b/libraries/omnitruck_helpers.rb
@@ -1,0 +1,137 @@
+#
+# Copyright (c) 2014-2015, Chef Software, Inc. <legal@chef.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative './helpers'
+require 'net/http'
+require 'json'
+
+module ChefIngredientCookbook
+  # The code in this module will eventually go into mixlib-install
+  module OmnitruckHelpers
+    include Helpers
+
+    # TODO: This method should get product name as a parameter and find the
+    # latest version for it.
+    def current_version(product_name)
+      unless ['chef', 'chefdk'].include?(product_name)
+        raise "Unknown product #{product_name}"
+      end
+
+      JSON.parse("/opt/#{product_name}/version-manifest.json")['build_version']
+    end
+
+    # TODO: This method should get product name as a parameter and find the
+    # latest version for it.
+    def latest_available_version(product_name)
+      latest_metadata = omnitruck_get('/chef/metadata')
+
+      # Extract the relative path from the response from metadata endpoint
+      relative_path = latest_metadata["relpath"]
+
+      # Extract the version from the relative path
+      # TODO: support more than Mac OS X
+      relative_path.split('/').last[/^chef-(.*)\.dmg$/,1]
+    end
+
+    # TODO: This method should get product name as a parameter and find the
+    # latest version for it.
+    def configure_version(version)
+      # Install mixlib-install
+      chef_gem "#{new_resource.product_name}-mixlib-install" do # ~FC009 foodcritic needs an update
+        package_name 'mixlib-install'
+        compile_time true
+      end
+
+      declare_chef_run_stop_resource
+
+      script "install-#{new_resource.product_name}-#{version}" do
+        action :run
+        code lazy {
+          require 'mixlib/install'
+          installer = Mixlib::Install.new(project: new_resource.product_name, version: version)
+          installer.install_command
+        }
+        if new_resource.product_name == 'chef'
+          notifies :run, 'ruby_block[stop chef run]', :immediately
+        end
+      end
+
+
+    end
+
+    # TODO: Currently mixlib-install does not provide this functionality.
+    def uninstall_product(product_name)
+      # Install mixlib-install
+      chef_gem "#{new_resource.product_name}-mixlib-install" do # ~FC009 foodcritic needs an update
+        package_name 'mixlib-install'
+        compile_time true
+      end
+
+      script "uninstall-#{new_resource.product_name}" do
+        action :run
+        code lazy {
+          require 'mixlib/install'
+          installer = Mixlib::Install.new(project: new_resource.product_name)
+          installer.uninstall_command
+        }
+      end
+    end
+
+    private
+    def omnitruck_get(path)
+      parameters = platform_parameters.merge(channel_parameters(:current))
+      endpoint = 'https://www.chef.io/'
+
+      uri = URI.parse(endpoint)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == 'https')
+
+      full_path = [path, URI.encode_www_form(parameters)].join('?')
+      request = Net::HTTP::Get.new(full_path)
+      request['Accept'] = 'application/json'
+      res = http.request(request)
+
+      # Raise if response is not 2XX
+      res.value
+      JSON.parse(res.body)
+    end
+
+    # Returns the platform parameters that omnitruck understands
+    def platform_parameters
+      # TODO: Support things other than Mac OS X 10.10
+      {
+        p: 'mac_os_x',
+        pv: '10.10',
+        m: 'x86_64'
+      }
+    end
+
+    # Returns the channel parameters that omnitruck understands
+    # TODO: This is not quite right. Currently omnitruck does not look at
+    # builds that are posted to s3://opscode-omnibus-packages-current
+    # so we need to change this.
+    def channel_parameters(channel)
+      if channel == :current
+        {
+          prerelease: true,
+          nightlies: true
+        }
+      else
+        {}
+      end
+    end
+  end
+end

--- a/libraries/omnitruck_helpers.rb
+++ b/libraries/omnitruck_helpers.rb
@@ -26,8 +26,8 @@ module ChefIngredientCookbook
     # TODO: This method should get product name as a parameter and find the
     # latest version for it.
     def current_version(product_name)
-      unless ['chef', 'chefdk'].include?(product_name)
-        raise "Unknown product #{product_name}"
+      unless %w(chef chefdk).include?(product_name)
+        fail "Unknown product #{product_name}"
       end
 
       JSON.parse("/opt/#{product_name}/version-manifest.json")['build_version']
@@ -35,15 +35,15 @@ module ChefIngredientCookbook
 
     # TODO: This method should get product name as a parameter and find the
     # latest version for it.
-    def latest_available_version(product_name)
+    def latest_available_version(_product_name)
       latest_metadata = omnitruck_get('/chef/metadata')
 
       # Extract the relative path from the response from metadata endpoint
-      relative_path = latest_metadata["relpath"]
+      relative_path = latest_metadata['relpath']
 
       # Extract the version from the relative path
       # TODO: support more than Mac OS X
-      relative_path.split('/').last[/^chef-(.*)\.dmg$/,1]
+      relative_path.split('/').last[/^chef-(.*)\.dmg$/, 1]
     end
 
     # TODO: This method should get product name as a parameter and find the
@@ -66,12 +66,10 @@ module ChefIngredientCookbook
           notifies :run, 'ruby_block[stop chef run]', :immediately
         end
       end
-
-
     end
 
     # TODO: Currently mixlib-install does not provide this functionality.
-    def uninstall_product(product_name)
+    def uninstall_product(_product_name)
       # Install mixlib-install
       chef_gem "#{new_resource.product_name}-mixlib-install" do # ~FC009 foodcritic needs an update
         package_name 'mixlib-install'
@@ -89,6 +87,7 @@ module ChefIngredientCookbook
     end
 
     private
+
     def omnitruck_get(path)
       parameters = platform_parameters.merge(channel_parameters(:current))
       endpoint = 'https://www.chef.io/'

--- a/libraries/omnitruck_helpers.rb
+++ b/libraries/omnitruck_helpers.rb
@@ -30,6 +30,10 @@ module ChefIngredientCookbook
         fail "Unknown product #{product_name}"
       end
 
+      # TODO(serdar): This logic does not work for products other than
+      # chef & chefdk since version-manifest is created under the
+      # install directory which can be different than the product name (e.g.
+      # chef-server -> /opt/opscode)
       JSON.parse("/opt/#{product_name}/version-manifest.json")['build_version']
     end
 
@@ -63,6 +67,7 @@ module ChefIngredientCookbook
           installer.install_command
         }
         if new_resource.product_name == 'chef'
+          # We define this resource in ChefIngredientProvider
           notifies :run, 'ruby_block[stop chef run]', :immediately
         end
       end

--- a/libraries/omnitruck_helpers.rb
+++ b/libraries/omnitruck_helpers.rb
@@ -55,8 +55,6 @@ module ChefIngredientCookbook
         compile_time true
       end
 
-      declare_chef_run_stop_resource
-
       script "install-#{new_resource.product_name}-#{version}" do
         action :run
         code lazy {

--- a/libraries/rhel_handler.rb
+++ b/libraries/rhel_handler.rb
@@ -32,6 +32,7 @@ module ChefIngredient
     end
 
     private
+
     def configure_package(action_name)
       if new_resource.package_source
         rpm_package new_resource.product_name do
@@ -55,9 +56,10 @@ module ChefIngredient
         # as an ephemeral attribute that is used during yum-chef recipe.
         node.set['yum-chef']['repo_name'] = "chef-#{new_resource.channel}"
         include_recipe 'yum-chef'
-        node.rm['yum-chef']['repo_name']
+        node.rm('yum-chef', 'repo_name')
 
-        package new_resource.product_name do
+        # Foodcritic doesn't like timeout attribute in package resource
+        package new_resource.product_name do # ~FC009
           action action_name
           package_name ingredient_package_name
           options new_resource.options

--- a/libraries/rhel_handler.rb
+++ b/libraries/rhel_handler.rb
@@ -16,16 +16,16 @@
 #
 
 module ChefIngredient
-  class RhelHandler
-    def install
+  module RhelHandler
+    def handle_install
+      configure_package(:install)
+    end
+
+    def handle_upgrade
       configure_package(:upgrade)
     end
 
-    def upgrade
-      configure_package(:upgrade)
-    end
-
-    def uninstall
+    def handle_uninstall
       package ingredient_package_name do
         action :remove
       end
@@ -52,11 +52,8 @@ module ChefIngredient
           only_if { ::File.exist?('/etc/apt/sources.list.d/chef_stable_.list') }
         end
 
-        # Enable the required yum-repository. We treat ['yum-chef']['repo_name']
-        # as an ephemeral attribute that is used during yum-chef recipe.
-        node.set['yum-chef']['repo_name'] = "chef-#{new_resource.channel}"
-        include_recipe 'yum-chef'
-        node.rm('yum-chef', 'repo_name')
+        # Enable the required yum-repository.
+        include_recipe "yum-chef::#{new_resource.channel}"
 
         # Foodcritic doesn't like timeout attribute in package resource
         package new_resource.product_name do # ~FC009

--- a/libraries/rhel_handler.rb
+++ b/libraries/rhel_handler.rb
@@ -42,6 +42,7 @@ module ChefIngredient
           source new_resource.package_source
 
           if new_resource.product_name == 'chef'
+            # We define this resource in ChefIngredientProvider
             notifies :run, 'ruby_block[stop chef run]', :immediately
           end
         end
@@ -49,7 +50,7 @@ module ChefIngredient
         # This is to cleanup old cruft from chef-server-ingredient
         file '/etc/yum.repos.d/chef_stable_.repo' do
           action :delete
-          only_if { ::File.exist?('/etc/apt/sources.list.d/chef_stable_.list') }
+          only_if { ::File.exist?('/etc/yum.repos.d/chef_stable_.repo') }
         end
 
         # Enable the required yum-repository.
@@ -68,6 +69,7 @@ module ChefIngredient
           timeout new_resource.timeout
 
           if new_resource.product_name == 'chef'
+            # We define this resource in ChefIngredientProvider
             notifies :run, 'ruby_block[stop chef run]', :immediately
           end
         end

--- a/libraries/rhel_handler.rb
+++ b/libraries/rhel_handler.rb
@@ -45,6 +45,10 @@ module ChefIngredient
           package_name ingredient_package_name
           options new_resource.options
           source new_resource.package_source
+
+          if new_resource.product_name == 'chef'
+            notifies :run, 'ruby_block[stop chef run]', :immediately
+          end
         end
       else
         include_recipe 'yum-chef'
@@ -56,6 +60,10 @@ module ChefIngredient
           # TODO: Hrmmm not sure why are we fucking with the given version this much.
           version install_version if Mixlib::Versioning.parse(version_string(new_resource.version)) > '0.0.0'
           timeout new_resource.timeout
+
+          if new_resource.product_name == 'chef'
+            notifies :run, 'ruby_block[stop chef run]', :immediately
+          end
         end
       end
     end

--- a/libraries/rhel_handler.rb
+++ b/libraries/rhel_handler.rb
@@ -1,0 +1,63 @@
+#
+# Author:: Serdar Sutay <serdar@chef.io>
+# Copyright (c) 2015, Chef Software, Inc. <legal@chef.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ChefIngredient
+  class RhelHandler
+    def install
+      configure_package(:upgrade)
+    end
+
+    def upgrade
+      configure_package(:upgrade)
+    end
+
+    def uninstall
+      package ingredient_package_name do
+        action :remove
+      end
+    end
+
+    private
+    def configure_package(action_name)
+      # TODO: Hrmmm this is interesting? stable? delete this every time?
+      file '/etc/yum.repos.d/chef_stable_.repo' do
+        action :delete
+        only_if { ::File.exist?('/etc/apt/sources.list.d/chef_stable_.list') }
+      end
+
+      if new_resource.package_source
+        rpm_package new_resource.product_name do
+          action action_name
+          package_name ingredient_package_name
+          options new_resource.options
+          source new_resource.package_source
+        end
+      else
+        include_recipe 'yum-chef'
+
+        package new_resource.product_name do
+          action action_name
+          package_name ingredient_package_name
+          options new_resource.options
+          # TODO: Hrmmm not sure why are we fucking with the given version this much.
+          version install_version if Mixlib::Versioning.parse(version_string(new_resource.version)) > '0.0.0'
+          timeout new_resource.timeout
+        end
+      end
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,5 +8,5 @@ description 'Primitives for managing Chef products and packages'
 source_url 'https://github.com/chef-cookbooks/chef-ingredient' if defined?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/chef-ingredient/issues' if defined?(:issues_url)
 
-depends 'apt-chef'
-depends 'yum-chef'
+depends 'apt-chef', '~> 0.2.0'
+depends 'yum-chef', '~> 0.2.0'

--- a/spec/unit/recipes/test_chef_spec.rb
+++ b/spec/unit/recipes/test_chef_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'test::chef' do
+  context 'install chef on ubuntu' do
+    cached(:ubuntu_1404) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04',
+        step_into: %w(chef_ingredient)
+      ).converge(described_recipe)
+    end
+
+    it 'sets up current apt repository' do
+      expect(ubuntu_1404).to add_apt_repository('chef-current')
+    end
+
+    it 'pins future installs of chef to current repository' do
+      expect(ubuntu_1404).to add_apt_preference('chef').with(pin: 'release o=https://packagecloud.io/chef/current',
+                                                             pin_priority: '900')
+    end
+
+    it 'installs chef' do
+      expect(ubuntu_1404).to install_package('chef')
+    end
+
+    it 'stops the run' do
+      chef_install_resource = ubuntu_1404.package('chef')
+      expect(chef_install_resource).to notify('ruby_block[stop chef run]').to(:run).immediately
+    end
+  end
+end

--- a/spec/unit/recipes/test_different_channels.rb
+++ b/spec/unit/recipes/test_different_channels.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'test::different_channels' do
+  context 'different channels on ubuntu' do
+    cached(:ubuntu_1404) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04',
+        step_into: %w(chef_ingredient)
+      ).converge(described_recipe)
+    end
+
+    it 'sets up stable apt repository' do
+      expect(ubuntu_1404).to add_apt_repository('chef-stable')
+    end
+
+    it 'pins future installs of chef-server to stable repository' do
+      expect(ubuntu_1404).to add_apt_preference('chef-server-core').with(pin: 'release o=https://packagecloud.io/chef/stable',
+                                                                         pin_priority: '900')
+    end
+
+    it 'installs chef-server' do
+      expect(ubuntu_1404).to install_package('chef-server-core')
+    end
+
+    it 'sets up current apt repository' do
+      expect(ubuntu_1404).to add_apt_repository('chef-current')
+    end
+
+    it 'pins future installs of analytics to current repository' do
+      expect(ubuntu_1404).to add_apt_preference('opscode-analytics').with(pin: 'release o=https://packagecloud.io/chef/current',
+                                                                          pin_priority: '900')
+    end
+
+    it 'installs analytics' do
+      expect(ubuntu_1404).to install_package('opscode-analytics')
+    end
+  end
+end

--- a/spec/unit/recipes/test_ingredient_config_spec.rb
+++ b/spec/unit/recipes/test_ingredient_config_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 
 describe 'test::ingredient_config' do
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new.converge(described_recipe)
+    ChefSpec::SoloRunner.new(
+      step_into: ['ingredient_config']
+    ).converge(described_recipe)
   end
 
   it 'it renders ad hoc config' do
-    expect(chef_run).to add_ingredient_config('chef-server')
-    expect(chef_run).to render_ingredient_config('chef-server').with(config: "topology 'torus'")
+    expect(chef_run).to create_file('/etc/opscode/chef-server.rb').with(content: "topology 'torus'")
   end
 end

--- a/spec/unit/recipes/test_push_spec.rb
+++ b/spec/unit/recipes/test_push_spec.rb
@@ -27,7 +27,7 @@ describe 'test::push' do
       end.converge(described_recipe)
     end
 
-    it 'creates the yum repository'do
+    it 'creates the yum repository' do
       expect(centos_65).to create_yum_repository('chef-stable')
     end
 

--- a/spec/unit/recipes/test_upgrade_spec.rb
+++ b/spec/unit/recipes/test_upgrade_spec.rb
@@ -28,7 +28,14 @@ describe 'test::upgrade' do
     end
 
     it 'upgrades yum_package[chef-server]' do
-      expect(centos_65).to upgrade_package('chef-server-core')
+      # Since we have two resources with same name and identity we can't use
+      # the upgrade_package & install_package matchers directly.
+      chef_server_resources = centos_65.find_resources(:package)
+      expect(chef_server_resources.length).to eq(2)
+      expect(chef_server_resources[0].action.first).to eq(:install)
+      expect(chef_server_resources[0].package_name).to eq('chef-server-core')
+      expect(chef_server_resources[1].action.first).to eq(:upgrade)
+      expect(chef_server_resources[1].package_name).to eq('chef-server-core')
     end
   end
 
@@ -44,7 +51,14 @@ describe 'test::upgrade' do
     end
 
     it 'upgrades apt_package[chef-server]' do
-      expect(ubuntu_1404).to upgrade_package('chef-server-core')
+      # Since we have two resources with same name and identity we can't use
+      # the upgrade_package & install_package matchers directly.
+      chef_server_resources = ubuntu_1404.find_resources(:package)
+      expect(chef_server_resources.length).to eq(2)
+      expect(chef_server_resources[0].action.first).to eq(:install)
+      expect(chef_server_resources[0].package_name).to eq('chef-server-core')
+      expect(chef_server_resources[1].action.first).to eq(:upgrade)
+      expect(chef_server_resources[1].package_name).to eq('chef-server-core')
     end
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/chef.rb
+++ b/test/fixtures/cookbooks/test/recipes/chef.rb
@@ -1,0 +1,4 @@
+chef_ingredient 'chef' do
+  channel :current
+  version :latest
+end

--- a/test/fixtures/cookbooks/test/recipes/chefdk.rb
+++ b/test/fixtures/cookbooks/test/recipes/chefdk.rb
@@ -1,1 +1,11 @@
-chef_ingredient 'chefdk'
+chef_ingredient 'chefdk' do
+  action :install
+  channel :stable
+  version '0.5.1'
+end
+
+chef_ingredient 'chefdk' do
+  action :upgrade
+  channel :stable
+  version '0.7.0'
+end

--- a/test/fixtures/cookbooks/test/recipes/different_channels.rb
+++ b/test/fixtures/cookbooks/test/recipes/different_channels.rb
@@ -1,0 +1,11 @@
+chef_ingredient 'chef-server' do
+  channel :stable
+  version '12.2.0' # only available in stable
+  action :install
+end
+
+chef_ingredient 'analytics' do
+  channel :current
+  version '1.1.6+20150918090908.git.49.337923e' # only available in current
+  action :install
+end

--- a/test/fixtures/cookbooks/test/recipes/ingredient_config.rb
+++ b/test/fixtures/cookbooks/test/recipes/ingredient_config.rb
@@ -1,6 +1,6 @@
 ingredient_config 'chef-server' do
   action :add
-  config  "topology 'torus'"
+  config "topology 'torus'"
 end
 
 ingredient_config 'chef-server'

--- a/test/integration/chefdk/serverspec/test_chefdk_spec.rb
+++ b/test/integration/chefdk/serverspec/test_chefdk_spec.rb
@@ -4,4 +4,8 @@ describe 'test::chefdk' do
   describe package('chefdk') do
     it { should be_installed }
   end
+
+  it 'chefdk should be upgraded' do
+    expect(package('chefdk').version).to eq('0.7.0-1')
+  end
 end

--- a/test/integration/different_channels/serverspec/assert_install_from_different_repos_spec.rb
+++ b/test/integration/different_channels/serverspec/assert_install_from_different_repos_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'chef-ingredient::default' do
+  it 'chef-server-core should be installed from stable' do
+    # This version is only available in stable
+    expect(package('chef-server-core').version).to eq('12.2.0-1')
+  end
+
+  it 'opscode-analytics should be installed from current' do
+    # This version is only available in current
+    expect(package('opscode-analytics').version).to eq('1.1.6+20150918090908.git.49.337923e-1')
+  end
+end


### PR DESCRIPTION
```ruby
# SPEC

# Installs specific version of a product. If an older version exists upgrades,
# if a newer version exists downgrades.
chef_ingredient "chef" do
  action :install
  version '12.5.0'
  channel :current # default is :stable
end

# Installs the latest version of a product. If an older or newer version exists,
# does not do anything.
chef_ingredient 'chef' do
  action :install
  channel :stable
end

# Always installs the latest version of a product.
chef_ingredient 'chef' do
  action :upgrade
  channel :current
end

# chef run is always stopped when 'chef' product is installed or upgraded.
# using :reconfigure action with client products results in a warning message
#   and no action.
# chef-ingredient supports installing and upgrading chef on all platforms.
# on platforms that is supported via native repositories, chef-ingredient uses
#   native package managers. Otherwise it uses mixlib-install to install these
#   products from omnitruck.
# all installation specific logic goes into mixlib-install and all resource /
#   provider logic goes into chef-ingredient.
```

Supporting versions other than `:latest` (as explained in https://github.com/chef-cookbooks/chef-ingredient/issues/39) is not in the scope of this work.

There are two remaining items but will have different PRs for them since this is already a monster PR:

- Implement channel pinning on RHEL.
- Enable installations from omnitruck.