### PR TITLE
Enable installations from omnitruck for 'chef' on :stable channel.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,9 @@ platforms:
   # specifically for EL7, but we want to! And then we'll uncomment
   # this so we can test them in the kitchen.
   # - name: centos-7.1
+  - name: macosx-10.10
+    driver:
+      box: chef/macosx-10.10 # private
 
 suites:
   - name: default
@@ -54,6 +57,10 @@ suites:
       - recipe[test]
       - recipe[test::local]
     attributes:
+
+  - name: chef
+    run_list:
+      - recipe[test::chef]
 
   - name: chefdk
     run_list:

--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -42,9 +42,8 @@ class Chef
           extend ::ChefIngredient::DebianHandler
         when 'rhel'
           extend ::ChefIngredient::RhelHandler
-          # TODO(serdar): Enable installations from Omnitruck
-          # else
-          #   extend ::ChefIngredient::OmnitruckHandler
+        else
+          extend ::ChefIngredient::OmnitruckHandler
         end
       end
 

--- a/libraries/omnitruck_handler.rb
+++ b/libraries/omnitruck_handler.rb
@@ -22,8 +22,10 @@ module ChefIngredient
     include ChefIngredientCookbook::OmnitruckHelpers
 
     def handle_install
+      verify_supported_products!
+
       current_version = current_version(new_resource.product_name)
-      latest_version = latest_available_version(new_resource.product_name)
+      latest_version = latest_available_version(new_resource.product_name, new_resource.channel)
 
       if new_resource.version == :latest
         # When we are installing :latest, we install only if there is no version right now
@@ -40,18 +42,22 @@ module ChefIngredient
     end
 
     def handle_upgrade
+      verify_supported_products!
+
       current_version = current_version(new_resource.product_name)
-      latest_version = latest_available_version(new_resource.product_name)
+      latest_version = latest_available_version(new_resource.product_name, new_resource.channel)
 
       candidate_version = new_resource.version == :latest ? latest_version : new_resource.version
 
-      # TODO: We need mixlib-versioning to be able to make this check correctly.
+      # MIXLIB-INSTALL: Use mixlib-install to do the > check on versions.
       if current_version.nil? || candidate_version > current_version
         configure_version(candidate_version)
       end
     end
 
     def handle_uninstall
+      verify_supported_products!
+
       uninstall_product(new_resource.product_name)
     end
   end

--- a/spec/unit/recipes/test_chef_spec.rb
+++ b/spec/unit/recipes/test_chef_spec.rb
@@ -20,7 +20,7 @@ describe 'test::chef' do
     end
 
     it 'installs chef' do
-      expect(ubuntu_1404).to install_package('chef')
+      expect(ubuntu_1404).to upgrade_package('chef')
     end
 
     it 'stops the run' do

--- a/test/fixtures/cookbooks/test/recipes/chef.rb
+++ b/test/fixtures/cookbooks/test/recipes/chef.rb
@@ -1,4 +1,5 @@
 chef_ingredient 'chef' do
   channel :current
   version :latest
+  action :upgrade
 end


### PR DESCRIPTION
@jtimberman I am on the fence to merge this or not. Current things work for the `:stable` channel for `'chef'` product. For `:current` channel we fail like this:

```
       Downloading https://www.chef.io/chef/install.sh to file /tmp/install.sh
       Trying curl...
       Download complete.
       Downloading Chef 12.5.0%252B20150924011016-1 for mac_os_x...
       downloading https://www.chef.io/chef/metadata?v=12.5.0%252B20150924011016-1&prerelease=false&nightlies=false&p=mac_os_x&pv=10.10&m=x86_64
         to file /var/folders/1x/d4nywty952x049kr8kngz1x00000gn/T//install.sh.546/metadata.txt
       trying curl...
       ERROR 404
       2.5.0%252B20150924011016-1 on platform mac_os_x

       Either this means:
          - We do not support mac_os_x
          - We do not have an artifact for 12.5.0%252B20150924011016-1
```

There are a few things we need in order to get the current to work:

* Point `install.sh` to the new omnitruck instead of `https://www.chef.io/chef/metadata`
* Deal with the url encoding and iteration number in the build versions: `12.5.0%252B20150924011016-1`

Work will happen on mixlib-install in the near future to handle these cases. Meanwhile I am not sure if we merge this or wait until the full functionality to work correctly.