### PR TITLE
We use ChefDK 0.9.0 and policyfiles

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: './test/fixtures/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -2,8 +2,6 @@ name 'chef-ingredient'
 run_list 'chef-ingredient::default'
 default_source :community
 
-cookbook 'chef-ingredient',
-  path: '.'
+cookbook 'chef-ingredient', path: '.'
 
-cookbook 'test',
-  path: './test/fixtures/cookbooks/test'
+cookbook 'test', path: './test/fixtures/cookbooks/test'

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This cookbook is supported by Chef's engineering services team.
 
 Chef version 12.1.0 or higher, latest/current version is always recommended.
 
+For local development, you need ChefDK 0.9.0 or newer.
+
 ### Cookbooks
 
 - apt

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,11 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
-# Requires https://github.com/sethvargo/chefspec/commit/cd57e28fdbd59fc26962c0dd3b1809b8841312f3
-# require 'chefspec/policyfile'
+RSpec.configure do |config|
+  config.color = true
+  config.formatter = 'doc'
+  config.log_level = :error
+end
 
 TOPDIR = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 SUPPORT_DIR = File.join(TOPDIR, 'spec', 'support')


### PR DESCRIPTION
- Remove berksfile
- Use policyfile w/ ChefSpec
- Configure RSpec for color, doc formatter, and error log level