### PR TITLE
Relax version constraints for dependencies

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,17 +6,14 @@ driver:
     cpus: 2
 
 provisioner:
-  name: chef_zero
+  name: policyfile_zero
   data_bags_path: test/fixtures/data_bags
 
 platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
   - name: centos-6.6
-  # TODO: (jtimberman) We do not currently create packages
-  # specifically for EL7, but we want to! And then we'll uncomment
-  # this so we can test them in the kitchen.
-  # - name: centos-7.1
+  - name: centos-7.1
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,5 +8,5 @@ description 'Primitives for managing Chef products and packages'
 source_url 'https://github.com/chef-cookbooks/chef-ingredient' if defined?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/chef-ingredient/issues' if defined?(:issues_url)
 
-depends 'apt-chef', '~> 0.2.0'
-depends 'yum-chef', '~> 0.2.0'
+depends 'apt-chef', '>= 0.2.0'
+depends 'yum-chef', '>= 0.2.0'


### PR DESCRIPTION
We need to use >= instead of ~> for version constraints because Chef
Policies use "dotted decimal identifier" versions that result in
integers that will never match the "normal" cookbook versions we use.

For example, the version constraint:

~> 3.2

is what we used. However, the dotted decimal version may be

30625036585770760.42672982950081083.162968991950205

The dotted decimal version is used in the "backwards compatibility
mode" for Chef Zero as it doesn't have the native Policy document API
(yet). This may result in a 412 precondition failed exception when
using the pessmistic version constraint.