### PR TITLE
We must use_inline_resources

### DIFF
--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -24,7 +24,7 @@ class Chef
   class Provider
     class ChefIngredient < Chef::Provider::LWRPBase
       provides :chef_ingredient
-      # use_inline_resources
+      use_inline_resources
 
       # for using include_recipe
       require 'chef/dsl/include_recipe'

--- a/libraries/ingredient_config_provider.rb
+++ b/libraries/ingredient_config_provider.rb
@@ -22,7 +22,7 @@ class Chef
       provides :ingredient_config
       include ChefIngredientCookbook::Helpers
 
-      # use_inline_resources
+      use_inline_resources
 
       def whyrun_supported?
         true

--- a/libraries/omnibus_service_provider.rb
+++ b/libraries/omnibus_service_provider.rb
@@ -24,7 +24,7 @@ class Chef
       # Methods for use in resources, found in helpers.rb
       include ChefIngredientCookbook::Helpers
 
-      # use_inline_resources
+      use_inline_resources
 
       def whyrun_supported?
         true


### PR DESCRIPTION
In commit c3f44ac, `use_inline_resources` was commented out. It is required in the `chef_ingredient` resource:

1. We send notifications in the various action helper methods that rely on operating against resources in the context of the `chef_ingredient` resource
2. It's the default in Chef 12.5 custom resources because the interaction is better for resources that are composed of other Chef resources as `chef_ingredient`