### PR TITLE
Content accumulator guard

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -127,7 +127,7 @@ module ChefIngredientCookbook
       # foodcritic thinks we are accessing a node attribute
       node.run_state[:ingredient_config_data] ||= {}              # ~FC001
       node.run_state[:ingredient_config_data][product] ||= ''     # ~FC001
-      node.run_state[:ingredient_config_data][product] += content # ~FC001
+      node.run_state[:ingredient_config_data][product] += content unless node.run_state[:ingredient_config_data][product].include?(content) # ~FC001
     end
 
     def get_config(product)


### PR DESCRIPTION
Because of the way we manipulate run contexts in resources, and resource
event notifications, we need to ensure that we aren't accumulating the
configuration file content multiple times when the `add_config` method
is used.