### PR TITLE
Remove push-client-jobs package naming assumption.

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -113,7 +113,7 @@ module ChefIngredientCookbook
       elsif (product == 'push-server') && (v < Mixlib::Versioning.parse('2.0.0'))
         data['package-name'] = 'opscode-push-jobs-server'
         data['ctl-command'] = 'opscode-push-jobs-server-ctl'
-      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('2.0.0'))
+      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('1.3.0'))
         data['package-name'] = 'opscode-push-jobs-client'
       end
 


### PR DESCRIPTION
There was a hard-coded override of the package-name which was incorrect
in assuming any version of the push-client-jobs < 2.0.0 was prefixed
with opscode. While this may have been true at some point in time, it
does not reflect what is on packagecloud currently.