### PR TITLE
Fixes issue #61 - package renaming

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -113,7 +113,7 @@ module ChefIngredientCookbook
       elsif (product == 'push-server') && (v < Mixlib::Versioning.parse('2.0.0'))
         data['package-name'] = 'opscode-push-jobs-server'
         data['ctl-command'] = 'opscode-push-jobs-server-ctl'
-      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('1.3.4') && (v > Mixlib::Versioning.parse('0.0.0')))
+      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('1.3.3') && (v > Mixlib::Versioning.parse('0.0.0')))
         data['package-name'] = 'opscode-push-jobs-client'
       elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('2.0.0'))
         data['package-name'] = 'push-jobs-client'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -113,8 +113,10 @@ module ChefIngredientCookbook
       elsif (product == 'push-server') && (v < Mixlib::Versioning.parse('2.0.0'))
         data['package-name'] = 'opscode-push-jobs-server'
         data['ctl-command'] = 'opscode-push-jobs-server-ctl'
-      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('2.0.0'))
+      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('1.3.4') && (v > Mixlib::Versioning.parse('0.0.0')))
         data['package-name'] = 'opscode-push-jobs-client'
+      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('2.0.0'))
+        data['package-name'] = 'push-jobs-client'
       end
 
       data


### PR DESCRIPTION
Fixes issue #61 
- If a version greater than 0.0.0 and less than 1.3.3 is supplied then install *opscode-push-jobs-client*
- If a version 1.3.3 or greater is specified use *push-jobs-client*
- If nothing is specified use *push-jobs-client*