### PR TITLE
Bring Your Own Packages #62

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -113,7 +113,7 @@ module ChefIngredientCookbook
       elsif (product == 'push-server') && (v < Mixlib::Versioning.parse('2.0.0'))
         data['package-name'] = 'opscode-push-jobs-server'
         data['ctl-command'] = 'opscode-push-jobs-server-ctl'
-      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('1.3.4') && (v > Mixlib::Versioning.parse('0.0.0')))
+      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('1.3.3') && (v > Mixlib::Versioning.parse('0.0.0')))
         data['package-name'] = 'opscode-push-jobs-client'
       elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('2.0.0'))
         data['package-name'] = 'push-jobs-client'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -113,8 +113,10 @@ module ChefIngredientCookbook
       elsif (product == 'push-server') && (v < Mixlib::Versioning.parse('2.0.0'))
         data['package-name'] = 'opscode-push-jobs-server'
         data['ctl-command'] = 'opscode-push-jobs-server-ctl'
-      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('2.0.0'))
+      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('1.3.4') && (v > Mixlib::Versioning.parse('0.0.0')))
         data['package-name'] = 'opscode-push-jobs-client'
+      elsif (product == 'push-client') && (v < Mixlib::Versioning.parse('2.0.0'))
+        data['package-name'] = 'push-jobs-client'
       end
 
       data


### PR DESCRIPTION
Provides the ability to "Bring Your Own Packages" for companies where direct connections to the internet are not possible - as referenced in #62 
* Setting node['chef-ingredient']['byop'] == true skips the recipe inclusion of apt-chef/yum-chef and any configuration that occurs.