### PR TITLE
Fix default naming now that Manage 2+ has shipped

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -220,9 +220,9 @@ module ChefIngredientCookbook
           'config-file'  => nil
         },
         'manage' => {
-          'package-name' => 'opscode-manage',
-          'ctl-command'  => 'opscode-manage-ctl',
-          'config-file'  => '/etc/opscode-manage/manage.rb'
+          'package-name' => 'chef-manage',
+          'ctl-command'  => 'chef-manage-ctl',
+          'config-file'  => '/etc/chef-manage/manage.rb'
         },
         'private-chef' => {
           'package-name' => 'private-chef',

--- a/spec/unit/recipes/test_repo_spec.rb
+++ b/spec/unit/recipes/test_repo_spec.rb
@@ -51,11 +51,11 @@ EOS
       end
 
       it 'creates config directory for manage' do
-        expect(chef_run).to create_directory('/etc/opscode-manage')
+        expect(chef_run).to create_directory('/etc/chef-manage')
       end
 
       it 'creates config file for manage with sensitive set' do
-        expect(chef_run).to create_file('/etc/opscode-manage/manage.rb').with sensitive: true, content: <<-EOS
+        expect(chef_run).to create_file('/etc/chef-manage/manage.rb').with sensitive: true, content: <<-EOS
 disable_sign_up true
 support_email_address "admin@chef.io"
 EOS


### PR DESCRIPTION
This change effectively reverts fb1f877 now that the default Management Console package is named `chef-manage`: https://github.com/chef/chef-web-downloads/pull/277

/cc @chef-cookbooks/engineering-services @smith @mmzyk @raskchanky @Padgett