### PR TITLE
Update push server package naming assumption

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -124,7 +124,7 @@ module ChefIngredientCookbook
       # need to implement similar logic to chef-server, so that the
       # default "latest" version, 0.0.0 (no constraint) doesn't result
       # in the old package.
-      elsif (product == 'push-server') && ((v < Mixlib::Versioning.parse('2.0.0')) && (v > Mixlib::Versioning.parse('0.0.0')))
+      elsif (product == 'push-server') && ((v < Mixlib::Versioning.parse('1.3.0')) && (v > Mixlib::Versioning.parse('0.0.0')))
         data['package-name'] = 'opscode-push-jobs-server'
         data['ctl-command'] = 'opscode-push-jobs-server-ctl'
       elsif (product == 'push-client') && ((v < Mixlib::Versioning.parse('1.3.0')) && (v > Mixlib::Versioning.parse('0.0.0')))


### PR DESCRIPTION
PR to update push-server package naming, using https://github.com/chef-cookbooks/chef-ingredient/pull/66 as a template for the fix.