### PR TITLE
Do not assume connection to the interwebs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.15.1
+
+- [#62](https://github.com/chef-cookbooks/chef-ingredient/issues/62) Do not assume connection to the interwebs
+
 # v0.15.0
 
 - [#66](https://github.com/chef-cookbooks/chef-ingredient/pull/66) Fix push job client and server naming

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -5,3 +5,4 @@ default_source :community
 cookbook 'chef-ingredient', path: '.'
 
 cookbook 'test', path: './test/fixtures/cookbooks/test'
+cookbook 'custom_repo', path: './test/fixtures/cookbooks/custom_repo'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,24 @@
+#
+# Author:: Salim Afiune <afiune@chef.io>
+# Copyright (c) 2015, Chef Software, Inc. <legal@chef.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Custom repository setup recipe
+#
+# When the user specifies this attribute chef-ingredient will not configure
+# our default packagecloud Chef repositories and instead it will include the
+# custom recipe. This will eliminate the hard dependency to the internet.
+#
+default['chef-ingredient']['custom_repo_setup_recipe'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,10 +15,13 @@
 # limitations under the License.
 #
 
-# Custom repository setup recipe
+default['chef-ingredient'] = {}
+
+# Set `custom-repo-recipe` to a string "cookbook::recipe" to specify
+# a custom recipe that sets up your own yum/apt repository where you have
+# mirrored the ingredient packages you want to use.
 #
-# When the user specifies this attribute chef-ingredient will not configure
-# our default packagecloud Chef repositories and instead it will include the
-# custom recipe. This will eliminate the hard dependency to the internet.
+# Do this elsewhere in your cookbook where you use chef_ingredient, in a
+# policyfile, environment, role, etc.
 #
-default['chef-ingredient']['custom_repo_setup_recipe'] = nil
+# default['chef-ingredient']['custom-repo-recipe'] = 'custom_repo::awesome_custom_setup'

--- a/libraries/debian_handler.rb
+++ b/libraries/debian_handler.rb
@@ -53,13 +53,18 @@ module ChefIngredient
           end
         end
       else
-        # Enable the required apt-repository.
-        include_recipe "apt-chef::#{new_resource.channel}"
+        if custom_repo_setup_recipe
+          # Use the custom repository setup.
+          include_recipe custom_repo_setup_recipe
+        else
+          # Enable the required apt-repository.
+          include_recipe "apt-chef::#{new_resource.channel}"
 
-        # Pin it so that product can only be installed from its own channel
-        apt_preference ingredient_package_name do
-          pin "release o=https://packagecloud.io/chef/#{new_resource.channel}"
-          pin_priority '900'
+          # Pin it so that product can only be installed from its own channel
+          apt_preference ingredient_package_name do
+            pin "release o=https://packagecloud.io/chef/#{new_resource.channel}"
+            pin_priority '900'
+          end
         end
 
         # Foodcritic doesn't like timeout attribute in package resource

--- a/libraries/debian_handler.rb
+++ b/libraries/debian_handler.rb
@@ -53,9 +53,9 @@ module ChefIngredient
           end
         end
       else
-        if custom_repo_setup_recipe
-          # Use the custom repository setup.
-          include_recipe custom_repo_setup_recipe
+        if use_custom_repo_recipe?
+          # Use the custom repository recipe.
+          include_recipe custom_repo_recipe
         else
           # Enable the required apt-repository.
           include_recipe "apt-chef::#{new_resource.channel}"

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -110,14 +110,21 @@ module ChefIngredientCookbook
     end
 
     #
-    # Returns the custom setup recipe
+    # Returns true if the custom repo recipe was specified
+    #
+    def use_custom_repo_recipe?
+      node['chef-ingredient'].attribute?('custom-repo-recipe')
+    end
+
+    #
+    # Returns the custom setup recipe name
     #
     # When the user specifies this attribute chef-ingredient will not configure
     # our default packagecloud Chef repositories and instead it will include the
     # custom recipe. This will eliminate the hard dependency to the internet.
     #
-    def custom_repo_setup_recipe
-      node['chef-ingredient']['custom_repo_setup_recipe'] if node['chef-ingredient']
+    def custom_repo_recipe
+      node['chef-ingredient']['custom-repo-recipe']
     end
 
     #

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -110,7 +110,11 @@ module ChefIngredientCookbook
     end
 
     #
-    # Returns the custom recipe that will setup the repository where we
+    # Returns the custom setup recipe
+    #
+    # When the user specifies this attribute chef-ingredient will not configure
+    # our default packagecloud Chef repositories and instead it will include the
+    # custom recipe. This will eliminate the hard dependency to the internet.
     #
     def custom_repo_setup_recipe
       node['chef-ingredient']['custom_repo_setup_recipe'] if node['chef-ingredient']

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -110,6 +110,13 @@ module ChefIngredientCookbook
     end
 
     #
+    # Returns the custom recipe that will setup the repository where we
+    #
+    def custom_repo_setup_recipe
+      node['chef-ingredient']['custom_repo_setup_recipe'] if node['chef-ingredient']
+    end
+
+    #
     # Returns the version string to use in package resource for all platforms.
     #
     def version_for_package_resource

--- a/libraries/rhel_handler.rb
+++ b/libraries/rhel_handler.rb
@@ -53,9 +53,9 @@ module ChefIngredient
           only_if { ::File.exist?('/etc/yum.repos.d/chef_stable_.repo') }
         end
 
-        if custom_repo_setup_recipe
-          # Use the custom repository setup.
-          include_recipe custom_repo_setup_recipe
+        if use_custom_repo_recipe?
+          # Use the custom repository recipe.
+          include_recipe custom_repo_recipe
         else
           # Enable the required yum-repository.
           include_recipe "yum-chef::#{new_resource.channel}"
@@ -65,7 +65,7 @@ module ChefIngredient
         package new_resource.product_name do # ~FC009
           action action_name
           package_name ingredient_package_name
-          if custom_repo_setup_recipe
+          if use_custom_repo_recipe?
             # Respect the options that the user has specified
             options new_resource.options
           else

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'chef-ingredient'
-version '0.15.0'
+version '0.15.1'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'

--- a/spec/unit/recipes/test_custom_repo_setup_recipe_spec.rb
+++ b/spec/unit/recipes/test_custom_repo_setup_recipe_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'test::custom_repo_setup_recipe' do
+
+  context 'on centos' do
+    cached(:centos_65) do
+      ChefSpec::SoloRunner.new(
+        platform: 'centos',
+        version: '6.5',
+        step_into: %w(chef_ingredient)
+      ).converge(described_recipe)
+    end
+
+    it 'does not creates the yum repository' do
+      expect(centos_65).to_not create_yum_repository('chef-stable')
+    end
+
+    it 'installs yum_package[chef-server]' do
+      pkgres = centos_65.find_resource('package', 'chef-server')
+      expect(pkgres).to_not be_nil
+      expect(pkgres).to be_a(Chef::Resource::YumPackage)
+      expect(centos_65).to install_package('chef-server')
+    end
+
+    it 'includes the custom_repo_setup_recipe' do
+      expect(centos_65).to include_recipe 'my_awesome::repo_recipe'
+    end
+  end
+
+  context 'on ubuntu' do
+    cached(:ubuntu_1404) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04',
+        step_into: %w(chef_ingredient)
+      ).converge(described_recipe)
+    end
+
+    it 'does not sets up current apt repository' do
+      expect(ubuntu_1404).to_not add_apt_repository('chef-stable')
+    end
+
+    it 'does not pins future installs of chef to current repository' do
+      expect(ubuntu_1404).to_not add_apt_preference('chef').with(pin: 'release o=https://packagecloud.io/chef/current',
+                                                             pin_priority: '900')
+    end
+
+    it 'installs chef' do
+      expect(ubuntu_1404).to install_package('chef-server')
+    end
+
+    it 'includes the custom_repo_setup_recipe' do
+      expect(ubuntu_1404).to include_recipe 'my_awesome::repo_recipe'
+    end
+  end
+end

--- a/spec/unit/recipes/test_custom_repo_setup_recipe_spec.rb
+++ b/spec/unit/recipes/test_custom_repo_setup_recipe_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'test::custom_repo_setup_recipe' do
-
   context 'on centos' do
     cached(:centos_65) do
       ChefSpec::SoloRunner.new(
@@ -23,7 +22,7 @@ describe 'test::custom_repo_setup_recipe' do
     end
 
     it 'includes the custom_repo_setup_recipe' do
-      expect(centos_65).to include_recipe 'my_awesome::repo_recipe'
+      expect(centos_65).to include_recipe 'custom_repo::awesome_custom_setup'
     end
   end
 
@@ -42,7 +41,7 @@ describe 'test::custom_repo_setup_recipe' do
 
     it 'does not pins future installs of chef to current repository' do
       expect(ubuntu_1404).to_not add_apt_preference('chef').with(pin: 'release o=https://packagecloud.io/chef/current',
-                                                             pin_priority: '900')
+                                                                 pin_priority: '900')
     end
 
     it 'installs chef' do
@@ -50,7 +49,7 @@ describe 'test::custom_repo_setup_recipe' do
     end
 
     it 'includes the custom_repo_setup_recipe' do
-      expect(ubuntu_1404).to include_recipe 'my_awesome::repo_recipe'
+      expect(ubuntu_1404).to include_recipe 'custom_repo::awesome_custom_setup'
     end
   end
 end

--- a/test/fixtures/cookbooks/custom_repo/metadata.rb
+++ b/test/fixtures/cookbooks/custom_repo/metadata.rb
@@ -1,0 +1,2 @@
+name 'custom_repo'
+version '0.0.1'

--- a/test/fixtures/cookbooks/custom_repo/recipes/awesome_custom_setup.rb
+++ b/test/fixtures/cookbooks/custom_repo/recipes/awesome_custom_setup.rb
@@ -1,0 +1,1 @@
+log 'configured an awesome custom repo'

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -2,3 +2,4 @@ name 'test'
 version '0.0.1'
 
 depends 'chef-ingredient'
+depends 'custom_repo'

--- a/test/fixtures/cookbooks/test/recipes/custom_repo_setup_recipe.rb
+++ b/test/fixtures/cookbooks/test/recipes/custom_repo_setup_recipe.rb
@@ -1,5 +1,5 @@
 # Configure a custom repository setup recipe
-node.set['chef-ingredient']['custom_repo_setup_recipe'] = 'custom_repo::awesome_custom_setup'
+node.set['chef-ingredient']['custom-repo-recipe'] = 'custom_repo::awesome_custom_setup'
 
 chef_ingredient 'chef-server' do
   action :install

--- a/test/fixtures/cookbooks/test/recipes/custom_repo_setup_recipe.rb
+++ b/test/fixtures/cookbooks/test/recipes/custom_repo_setup_recipe.rb
@@ -1,0 +1,6 @@
+# Configure a custom repository setup recipe
+node.set['chef-ingredient']['custom_repo_setup_recipe'] = 'my_awesome::repo_recipe'
+
+chef_ingredient 'chef-server' do
+  action :install
+end

--- a/test/fixtures/cookbooks/test/recipes/custom_repo_setup_recipe.rb
+++ b/test/fixtures/cookbooks/test/recipes/custom_repo_setup_recipe.rb
@@ -1,5 +1,5 @@
 # Configure a custom repository setup recipe
-node.set['chef-ingredient']['custom_repo_setup_recipe'] = 'my_awesome::repo_recipe'
+node.set['chef-ingredient']['custom_repo_setup_recipe'] = 'custom_repo::awesome_custom_setup'
 
 chef_ingredient 'chef-server' do
   action :install


### PR DESCRIPTION
Provides the ability to "Bring Your Own Repo Setup Recipe" for companies
where direct connections to the internet are not possible.

Setting `node['chef-ingredient']['custom_repo_setup_recipe']` pointing
to your own repository setup recipe will avoid the creation of any
**chef** specific repo pointing to packagecloud.

Closes https://github.com/chef-cookbooks/chef-ingredient/issues/62