### PR TITLE
Enable installation of chef and chefdk from unstable channel.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -42,6 +42,13 @@ suites:
     run_list:
       - recipe[test::chefdk]
 
+  # This test requires access to Chef's internal network
+  <% if ENV['ARTIFACTORY_USERNAME'] %>
+  - name: chef_unstable
+    run_list:
+      - recipe[test::unstable]
+  <% end %>
+
   - name: push_client
     # we don't yet have push client packages for trusty, only precise
     excludes: [ 'ubuntu-14.04', 'macosx-10.10', 'windows-server-2012r2-standard' ]

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ group :unit do
   gem 'chef-sugar'
   gem 'chefspec'
   gem 'chef-dk'
+
+  # Pin nokogiri to 1.6.7 until the new version can install in travis.
+  gem 'nokogiri', '= 1.6.7'
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ By default, `chef_ingredient` will install using Chef's public package repositor
 - `ctl_command`: The "ctl" command, e.g., `chef-server-ctl`. This should be automatically detected by the library helper method `chef_ctl_command`, but may need to be specified if something changes, like a new add-on is made available.
 - `options`: Options passed to the `package` resource used for installation.
 - `version`: Package version to install. Can be specified in various semver-alike ways: `12.0.4`, `12.0.3-rc.3`, and also `:latest`/`'latest'`. Do not use this property when specifying `package_source`. Default is `:latest`, which will install the latest package from the repository.
-- `channel`: Channel to install the products from. It can be `:stable` (default) or `:current`.
+- `channel`: Channel to install the products from. It can be `:stable` (default), `:current` or `:unstable`.
 - `package_source`: Full path to a location where the package is located. If present, this file is used for installing the package. Default `nil`.
 - `timeout`: The amount of time (in seconds) to wait to fetch the installer before timing out. Default: default timeout of the Chef package resource - `900` seconds.
 

--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -27,7 +27,7 @@ class Chef
 
       # Attributes for determining what version to install from which channel
       attribute :version, kind_of: [String, Symbol], default: :latest
-      attribute :channel, kind_of: Symbol, default: :stable, equal_to: [:current, :stable]
+      attribute :channel, kind_of: Symbol, default: :stable, equal_to: [:current, :stable, :unstable]
 
       # Attribute to install package from local file
       attribute :package_source, kind_of: String, default: nil

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -80,7 +80,7 @@ module ChefIngredientCookbook
     #
     def ensure_mixlib_install_gem_installed!
       node.run_state[:mixlib_install_gem_installed] ||= begin # ~FC001
-        install_gem_from_rubygems('mixlib-install', '0.8.0.alpha.2')
+        install_gem_from_rubygems('mixlib-install', '0.8.0.alpha.3')
 
         require 'mixlib/install'
         require 'mixlib/install/product'

--- a/test/fixtures/cookbooks/test/recipes/unstable.rb
+++ b/test/fixtures/cookbooks/test/recipes/unstable.rb
@@ -1,0 +1,22 @@
+#
+# This recipe tests the :unstable channel.
+# This channel is only accessible from Chef's internal
+# network and contains untested builds of Chef products.
+#
+# Make sure you set below environment variables for
+# tests to work correctly.
+#
+
+env 'ARTIFACTORY_USERNAME' do
+  value 'username@chef.io'
+end
+
+env 'ARTIFACTORY_PASSWORD' do
+  value 'XXXXXXXXXXXXX'
+end
+
+chef_ingredient 'chef' do
+  action :upgrade
+  channel :unstable
+  version :latest
+end


### PR DESCRIPTION
This PR enables `chef-ingredient` to install Chef Client and Chef DK from unstable channel. 

/cc: @chef-cookbooks/engineering-services 