### PR TITLE
Add support for unstable channel to Debian and RHEL handlers

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,9 +4,6 @@ driver:
   customize:
     memory: 2048
     cpus: 2
-  # TESTING: Uncomment synced_folders to test local mixlib-install builds
-  # synced_folders:
-  #   - ["/Users/patrickwright/github/mixlib-install/pkg", "/pkg"]
 
 provisioner:
   # TODO: (engineering-services) Switch this back to policyfile_zero
@@ -60,6 +57,10 @@ suites:
       artifactory:
         username: <%= ENV['ARTIFACTORY_USERNAME'] %>
         password: <%= ENV['ARTIFACTORY_PASSWORD'] %>
+      chef-ingredient:
+        mixlib-install:
+          # Set to install mixlib-install from source
+          git_ref: <%= ENV['MIXLIB_INSTALL_GIT_REF'] %>
 
   - name: unstable_chef_server
     excludes: [ 'macosx-10.10', 'windows-server-2012r2-standard' ]
@@ -69,6 +70,10 @@ suites:
       artifactory:
         username: <%= ENV['ARTIFACTORY_USERNAME'] %>
         password: <%= ENV['ARTIFACTORY_PASSWORD'] %>
+      chef-ingredient:
+        mixlib-install:
+          # Set to install mixlib-install from source
+          git_ref: <%= ENV['MIXLIB_INSTALL_GIT_REF'] %>
   <% end %>
 
   - name: push_client

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,9 @@ driver:
   customize:
     memory: 2048
     cpus: 2
+  # TESTING: Uncomment synced_folders to test local mixlib-install builds
+  # synced_folders:
+  #   - ["/Users/patrickwright/github/mixlib-install/pkg", "/pkg"]
 
 provisioner:
   # TODO: (engineering-services) Switch this back to policyfile_zero
@@ -43,11 +46,29 @@ suites:
     run_list:
       - recipe[test::chefdk]
 
-  # This test requires access to Chef's internal network
+  # Tests that require access to Chef's internal network
   <% if ENV['ARTIFACTORY_USERNAME'] %>
-  - name: chef_unstable
+  - name: unstable_chefdk
+    provisioner:
+      product_name: chefdk
+      product_version: latest
+      channel: stable
+    excludes: [ 'macosx-10.10', 'windows-server-2012r2-standard' ]
     run_list:
-      - recipe[test::unstable]
+      - recipe[test::unstable_chefdk]
+    attributes:
+      artifactory:
+        username: <%= ENV['ARTIFACTORY_USERNAME'] %>
+        password: <%= ENV['ARTIFACTORY_PASSWORD'] %>
+
+  - name: unstable_chef_server
+    excludes: [ 'macosx-10.10', 'windows-server-2012r2-standard' ]
+    run_list:
+      - recipe[test::unstable_chef_server]
+    attributes:
+      artifactory:
+        username: <%= ENV['ARTIFACTORY_USERNAME'] %>
+        password: <%= ENV['ARTIFACTORY_PASSWORD'] %>
   <% end %>
 
   - name: push_client

--- a/Berksfile
+++ b/Berksfile
@@ -3,3 +3,9 @@ metadata
 
 cookbook 'test', path: './test/fixtures/cookbooks/test'
 cookbook 'custom_repo', path: './test/fixtures/cookbooks/custom_repo'
+
+group :integration do
+  cookbook 'git', '~> 4.3'
+  cookbook 'apt', '~> 3.0'
+  cookbook 'yum', '~> 3.10'
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,12 @@
 
 default['chef-ingredient'] = {}
 
+#
+# Optionally install the mixlib-install gem from source. This ref can be
+# a revision, branch or tag.
+#
+default['chef-ingredient']['mixlib-install']['git_ref'] = nil
+
 # Set `custom-repo-recipe` to a string "cookbook::recipe" to specify
 # a custom recipe that sets up your own yum/apt repository where you have
 # mirrored the ingredient packages you want to use.

--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -22,7 +22,7 @@ require_relative './omnitruck_handler'
 
 class Chef
   class Provider
-    class ChefIngredient < Chef::Provider::LWRPBase
+    class ChefIngredient < Chef::Provider::LWRPBase # ~FC058
       provides :chef_ingredient
       use_inline_resources
 

--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -38,6 +38,10 @@ class Chef
       # Attributes for package resources used on rhel and debian platforms
       attribute :options, kind_of: String
       attribute :timeout, kind_of: [Integer, String, NilClass], default: nil
+
+      # Attributes for authenticating to artifactory to download unstable packages
+      attribute :artifactory_username, kind_of: String
+      attribute :artifactory_password, kind_of: String
     end
   end
 end

--- a/libraries/debian_handler.rb
+++ b/libraries/debian_handler.rb
@@ -110,6 +110,9 @@ module ChefIngredient
         channel: new_resource.channel,
         product_version: new_resource.version
       }
+
+      ENV['ARTIFACTORY_USERNAME'] = new_resource.artifactory_username
+      ENV['ARTIFACTORY_PASSWORD'] = new_resource.artifactory_password
       installer = Mixlib::Install.new(installer_options).detect_platform
 
       cache_path = Chef::Config[:file_cache_path]

--- a/libraries/omnitruck_handler.rb
+++ b/libraries/omnitruck_handler.rb
@@ -37,7 +37,7 @@ module ChefIngredient
     end
 
     def handle_uninstall
-      fail 'Uninstalling a product is currently not supported.'
+      raise 'Uninstalling a product is currently not supported.'
     end
 
     def configure_version(installer)
@@ -75,22 +75,6 @@ module ChefIngredient
             notifies :run, 'ruby_block[stop chef run]', :immediately
           end
         end
-      end
-    end
-
-    def installer
-      @installer ||= begin
-        ensure_mixlib_install_gem_installed!
-
-        options = {
-          product_name: new_resource.product_name,
-          channel: new_resource.channel,
-          product_version: new_resource.version
-        }.tap do |opt|
-          opt[:shell_type] = :ps1 if windows?
-        end
-
-        Mixlib::Install.new(options)
       end
     end
 

--- a/libraries/rhel_handler.rb
+++ b/libraries/rhel_handler.rb
@@ -107,6 +107,9 @@ module ChefIngredient
         channel: new_resource.channel,
         product_version: new_resource.version
       }
+
+      ENV['ARTIFACTORY_USERNAME'] = new_resource.artifactory_username
+      ENV['ARTIFACTORY_PASSWORD'] = new_resource.artifactory_password
       installer = Mixlib::Install.new(installer_options).detect_platform
 
       cache_path = Chef::Config[:file_cache_path]

--- a/libraries/rhel_handler.rb
+++ b/libraries/rhel_handler.rb
@@ -34,25 +34,17 @@ module ChefIngredient
     private
 
     def configure_package(action_name)
+      # This is to cleanup old cruft from chef-server-ingredient
+      file '/etc/yum.repos.d/chef_stable_.repo' do
+        action :delete
+        only_if { ::File.exist?('/etc/yum.repos.d/chef_stable_.repo') }
+      end
+
       if new_resource.package_source
-        rpm_package new_resource.product_name do
-          action action_name
-          package_name ingredient_package_name
-          options new_resource.options
-          source new_resource.package_source
-
-          if new_resource.product_name == 'chef'
-            # We define this resource in ChefIngredientProvider
-            notifies :run, 'ruby_block[stop chef run]', :immediately
-          end
-        end
+        configure_from_source_package(action_name)
+      elsif new_resource.channel == :unstable
+        configure_from_unstable_channel(action_name)
       else
-        # This is to cleanup old cruft from chef-server-ingredient
-        file '/etc/yum.repos.d/chef_stable_.repo' do
-          action :delete
-          only_if { ::File.exist?('/etc/yum.repos.d/chef_stable_.repo') }
-        end
-
         if use_custom_repo_recipe?
           # Use the custom repository recipe.
           include_recipe custom_repo_recipe
@@ -61,32 +53,72 @@ module ChefIngredient
           include_recipe "yum-chef::#{new_resource.channel}"
         end
 
-        # Foodcritic doesn't like timeout attribute in package resource
-        package new_resource.product_name do # ~FC009
-          action action_name
-          package_name ingredient_package_name
-          if use_custom_repo_recipe?
-            # Respect the options that the user has specified
-            options new_resource.options
-          else
-            # Ensure that we are installing from the correct repository
-            options "--disablerepo=* --enablerepo=chef-#{new_resource.channel} #{new_resource.options}"
-          end
+        configure_from_repo(action_name)
+      end
+    end
 
-          # If the latest version is specified, we should not give any version
-          # to the package resource.
-          unless version_latest?(new_resource.version)
-            version version_for_package_resource
-          end
+    def configure_from_source_package(action_name, local_path = nil)
+      rpm_package new_resource.product_name do
+        action action_name
+        package_name ingredient_package_name
+        options new_resource.options
+        source local_path || new_resource.package_source
 
-          timeout new_resource.timeout
-
-          if new_resource.product_name == 'chef'
-            # We define this resource in ChefIngredientProvider
-            notifies :run, 'ruby_block[stop chef run]', :immediately
-          end
+        if new_resource.product_name == 'chef'
+          # We define this resource in ChefIngredientProvider
+          notifies :run, 'ruby_block[stop chef run]', :immediately
         end
       end
+    end
+
+    def configure_from_repo(action_name)
+      # Foodcritic doesn't like timeout attribute in package resource
+      package new_resource.product_name do # ~FC009
+        action action_name
+        package_name ingredient_package_name
+        if use_custom_repo_recipe?
+          # Respect the options that the user has specified
+          options new_resource.options
+        else
+          # Ensure that we are installing from the correct repository
+          options "--disablerepo=* --enablerepo=chef-#{new_resource.channel} #{new_resource.options}"
+        end
+
+        # If the latest version is specified, we should not give any version
+        # to the package resource.
+        unless version_latest?(new_resource.version)
+          version version_for_package_resource
+        end
+
+        timeout new_resource.timeout
+
+        if new_resource.product_name == 'chef'
+          # We define this resource in ChefIngredientProvider
+          notifies :run, 'ruby_block[stop chef run]', :immediately
+        end
+      end
+    end
+
+    def configure_from_unstable_channel(action_name)
+      ensure_mixlib_install_gem_installed!
+
+      installer_options = {
+        product_name: new_resource.product_name,
+        channel: new_resource.channel,
+        product_version: new_resource.version
+      }
+      installer = Mixlib::Install.new(installer_options).detect_platform
+
+      cache_path = Chef::Config[:file_cache_path]
+      remote_artifact_path = installer.artifact_info.url
+      local_artifact_path = File.join(cache_path, ::File.basename(remote_artifact_path))
+
+      remote_file local_artifact_path do
+        source remote_artifact_path
+        mode '0644'
+      end
+
+      configure_from_source_package(action_name, local_artifact_path)
     end
   end
 end

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -3,3 +3,6 @@ version '0.0.1'
 
 depends 'chef-ingredient'
 depends 'custom_repo'
+depends 'git'
+depends 'apt'
+depends 'yum'

--- a/test/fixtures/cookbooks/test/recipes/compliance.rb
+++ b/test/fixtures/cookbooks/test/recipes/compliance.rb
@@ -7,15 +7,17 @@
 # tests to work correctly.
 #
 
-env 'ARTIFACTORY_USERNAME' do
-  value 'username@chef.io'
+include_recipe 'apt'
+include_recipe 'yum'
+include_recipe 'git'
+
+chef_ingredient 'compliance' do
+  action :install
+  channel :stable
+  version :latest
 end
 
-env 'ARTIFACTORY_PASSWORD' do
-  value 'XXXXXXXXXXXXX'
-end
-
-chef_ingredient 'chef' do
+chef_ingredient 'compliance' do
   action :upgrade
   channel :unstable
   version :latest

--- a/test/fixtures/cookbooks/test/recipes/unstable_chef_server.rb
+++ b/test/fixtures/cookbooks/test/recipes/unstable_chef_server.rb
@@ -7,11 +7,14 @@
 # tests to work correctly.
 #
 
-ENV['ARTIFACTORY_USERNAME'] = node['artifactory']['username']
-ENV['ARTIFACTORY_PASSWORD'] = node['artifactory']['password']
+include_recipe 'apt'
+include_recipe 'yum'
+include_recipe 'git'
 
 chef_ingredient 'chef-server' do
   action :install
   channel :unstable
   version :latest
+  artifactory_username node['artifactory']['username']
+  artifactory_password node['artifactory']['password']
 end

--- a/test/fixtures/cookbooks/test/recipes/unstable_chef_server.rb
+++ b/test/fixtures/cookbooks/test/recipes/unstable_chef_server.rb
@@ -1,0 +1,17 @@
+#
+# This recipe tests the :unstable channel.
+# This channel is only accessible from Chef's internal
+# network and contains untested builds of Chef products.
+#
+# Make sure you set below environment variables for
+# tests to work correctly.
+#
+
+ENV['ARTIFACTORY_USERNAME'] = node['artifactory']['username']
+ENV['ARTIFACTORY_PASSWORD'] = node['artifactory']['password']
+
+chef_ingredient 'chef-server' do
+  action :install
+  channel :unstable
+  version :latest
+end

--- a/test/fixtures/cookbooks/test/recipes/unstable_chefdk.rb
+++ b/test/fixtures/cookbooks/test/recipes/unstable_chefdk.rb
@@ -7,11 +7,14 @@
 # tests to work correctly.
 #
 
-ENV['ARTIFACTORY_USERNAME'] = node['artifactory']['username']
-ENV['ARTIFACTORY_PASSWORD'] = node['artifactory']['password']
+include_recipe 'apt'
+include_recipe 'yum'
+include_recipe 'git'
 
 chef_ingredient 'chefdk' do
   action :upgrade
   channel :unstable
   version :latest
+  artifactory_username node['artifactory']['username']
+  artifactory_password node['artifactory']['password']
 end

--- a/test/fixtures/cookbooks/test/recipes/unstable_chefdk.rb
+++ b/test/fixtures/cookbooks/test/recipes/unstable_chefdk.rb
@@ -1,0 +1,17 @@
+#
+# This recipe tests the :unstable channel.
+# This channel is only accessible from Chef's internal
+# network and contains untested builds of Chef products.
+#
+# Make sure you set below environment variables for
+# tests to work correctly.
+#
+
+ENV['ARTIFACTORY_USERNAME'] = node['artifactory']['username']
+ENV['ARTIFACTORY_PASSWORD'] = node['artifactory']['password']
+
+chef_ingredient 'chefdk' do
+  action :upgrade
+  channel :unstable
+  version :latest
+end


### PR DESCRIPTION
The core changes here are in DebianHandler and RhelHandler.  The `configure_package` has been split to support custom repos, source packages, and unstable channel using mixlib-install.

This PR also includes maintenance updates for rubocop and foodcritic.

Known Issues:
* chefdk upgrade kitchen tests are still broken (known issue)
* Unstable channel resolution not supported for Windows (a new PR will be created to add a WindowsHandler)
* Handlers contain some similar and duplicated code.  This should be fixed when we implement the WindowsHandler.

TODOs:
- [ :heavy_check_mark: ] Remove local test code (synced folders, chef_gem install)
- [ :heavy_check_mark: ] release next mixlib-install alpha version and update cookbook

@sersut 