### PR TITLE
Deprecate non-standard product names.

### DIFF
--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -48,6 +48,7 @@ class Chef
       end
 
       action :install do
+        check_deprecated_properties
         add_config(new_resource.product_name, new_resource.config)
         declare_chef_run_stop_resource
 
@@ -55,6 +56,7 @@ class Chef
       end
 
       action :upgrade do
+        check_deprecated_properties
         add_config(new_resource.product_name, new_resource.config)
         declare_chef_run_stop_resource
 
@@ -62,10 +64,12 @@ class Chef
       end
 
       action :uninstall do
+        check_deprecated_properties
         handle_uninstall
       end
 
       action :reconfigure do
+        check_deprecated_properties
         add_config(new_resource.product_name, new_resource.config)
 
         if ingredient_ctl_command.nil?

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -87,7 +87,7 @@ module ChefIngredientCookbook
             'mixlib-install'
           )
         else
-          install_gem_from_rubygems('mixlib-install', '0.8.0.alpha.7')
+          install_gem_from_rubygems('mixlib-install', '0.8.0.alpha.8')
         end
 
         require 'mixlib/install'
@@ -306,6 +306,35 @@ module ChefIngredientCookbook
       end
 
       options
+    end
+
+    #
+    # Checks the deprecated properties of chef-ingredient and prints warning
+    # messages if any of them are being used.
+    #
+    def check_deprecated_properties
+      # Historically we have had chef- and opscode- in front of most of our
+      # packages. But with our move to bintray we have standardized on names
+      # without any prefixes except some products.
+      if !%w(chef-backend chef-server chef-server-ha-provisioning).include?(new_resource.product_name) &&
+         (match = new_resource.product_name.match(/(chef-|opscode-)(?<product_key>.*)/))
+
+        new_product_key = match[:product_key]
+        Chef::Log.warn "product_name '#{new_resource.product_name}' is deprecated and it will be removed in the future versions of chef-ingredient. Use '#{new_product_key}' instead of '#{new_resource.product_name}'."
+        new_resource.product_name(new_product_key)
+      else
+        # We also have a specific case we need to handle for push-client and push-server
+        deprecated_product_names = {
+          'push-client' => 'push-jobs-client',
+          'push-server' => 'push-jobs-server'
+        }
+
+        if deprecated_product_names.keys.include?(new_resource.product_name)
+          new_product_key = deprecated_product_names[new_resource.product_name]
+          Chef::Log.warn "product_name '#{new_resource.product_name}' is deprecated and it will be removed in the future versions of chef-ingredient. Use '#{new_product_key}' instead of '#{new_resource.product_name}'."
+          new_resource.product_name(new_product_key)
+        end
+      end
     end
   end
 end

--- a/spec/unit/recipes/test_push_spec.rb
+++ b/spec/unit/recipes/test_push_spec.rb
@@ -32,10 +32,10 @@ describe 'test::push' do
     end
 
     it 'upgrades yum_package[push-client]' do
-      pkgres = centos_65.find_resource('package', 'push-client')
+      pkgres = centos_65.find_resource('package', 'push-jobs-client')
       expect(pkgres).to_not be_nil
       expect(pkgres).to be_a(Chef::Resource::YumPackage)
-      expect(centos_65).to install_package('push-client')
+      expect(centos_65).to install_package('push-jobs-client')
     end
   end
 
@@ -55,10 +55,10 @@ describe 'test::push' do
     end
 
     it 'upgrades apt_package[push-client]' do
-      pkgres = ubuntu_1404.find_resource('package', 'push-client')
+      pkgres = ubuntu_1404.find_resource('package', 'push-jobs-client')
       expect(pkgres).to_not be_nil
       expect(pkgres).to be_a(Chef::Resource::AptPackage)
-      expect(ubuntu_1404).to install_package('push-client')
+      expect(ubuntu_1404).to install_package('push-jobs-client')
     end
   end
 end


### PR DESCRIPTION
This PR deprecates chef-ha, chef-marketplace, chef-sync, push-client, push-server in favor of ha, marketplace, sync, push-jobs-client, push-jobs-server.

As we are moving to bintray, we have standardized these names in mixlib-install with https://github.com/chef/mixlib-install/pull/77/files . This PR makes sure that backwards compatibility is not broken for changed products. 

Fixes https://github.com/chef-cookbooks/chef-ingredient/issues/89. 

Note that `0.8.0.alpha.8` is the first version of mixlib-install where these new naming is introduced.

/cc: @chef-cookbooks/engineering-services 