### PR TITLE
Add accept_license property to chef-ingredient.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ By default, `chef_ingredient` will install using the `packages.chef.io` stable r
 - `channel`: Channel to install the products from. It can be `:stable` (default), `:current` or `:unstable`.
 - `package_source`: Full path to a location where the package is located. If present, this file is used for installing the package. Default `nil`.
 - `timeout`: The amount of time (in seconds) to wait to fetch the installer before timing out. Default: default timeout of the Chef package resource - `900` seconds.
+- `accept_license`: A boolean value that specifies if license should be accepted if it is asked for during `reconfigure`action. This option is applicable to only these products: manage, analytics, reporting and compliance. Default: `false`.
 
 ### omnibus_service
 

--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -89,9 +89,15 @@ class Chef
             # like /var/opt/<product_name> is to get the config file path that
             # looks like /etc/<product_name>/<product_name>.rb and do path
             # manipulation.
-            product_data_dir = ::File.basename(::File.dirname(ingredient_config_file(new_resource.product_name)))
+            product_data_dir_name = ::File.basename(::File.dirname(ingredient_config_file(new_resource.product_name)))
+            product_data_dir = ::File.join('/var/opt', product_data_dir_name)
 
-            file ::File.join('/var/opt', product_data_dir, '.license.accepted') do
+            directory product_data_dir do
+              recursive true
+              action :create
+            end
+
+            file ::File.join(product_data_dir, '.license.accepted') do
               action :touch
             end
           end

--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -38,6 +38,9 @@ class Chef
       # Attributes for package resources used on rhel and debian platforms
       attribute :options, kind_of: String
       attribute :timeout, kind_of: [Integer, String, NilClass], default: nil
+
+      # Attribute to accept the license when applicable
+      attribute :accept_license, kind_of: [TrueClass, FalseClass], default: false
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -53,7 +53,7 @@ module ChefIngredientCookbook
     #
     # Returns the ctl-command for a chef_ingredient resource
     #
-    def ingredient_config_file
+    def ingredient_config_file(product_name)
       ensure_mixlib_install_gem_installed!
 
       PRODUCT_MATRIX.lookup(product_name).config_file

--- a/resources/ingredient_config.rb
+++ b/resources/ingredient_config.rb
@@ -28,7 +28,7 @@ property :sensitive, [TrueClass, FalseClass], default: false
 property :config, String, default: nil
 
 action :render do
-  target_config = ingredient_config_file
+  target_config = ingredient_config_file(product_name)
   return if target_config.nil?
 
   directory ::File.dirname(target_config) do

--- a/spec/unit/recipes/test_config_spec.rb
+++ b/spec/unit/recipes/test_config_spec.rb
@@ -37,6 +37,10 @@ EOS
         expect(chef_run).to reconfigure_chef_server_ingredient('manage')
       end
 
+      it 'creates the directory for the license acceptance file' do
+        expect(chef_run).to create_directory('/var/opt/chef-manage').with(recursive: true)
+      end
+
       it 'creates the license acceptance file' do
         expect(chef_run).to touch_file('/var/opt/chef-manage/.license.accepted')
       end

--- a/spec/unit/recipes/test_config_spec.rb
+++ b/spec/unit/recipes/test_config_spec.rb
@@ -37,6 +37,10 @@ EOS
         expect(chef_run).to reconfigure_chef_server_ingredient('manage')
       end
 
+      it 'creates the license acceptance file' do
+        expect(chef_run).to touch_file('/var/opt/chef-manage/.license.accepted')
+      end
+
       it 'does not render config file using ingredient_config' do
         expect(chef_run).to_not render_ingredient_config('manage')
       end

--- a/test/fixtures/cookbooks/test/recipes/config.rb
+++ b/test/fixtures/cookbooks/test/recipes/config.rb
@@ -12,5 +12,6 @@ end
 
 # Management Console - using the compat shim resource
 chef_server_ingredient 'manage' do
+  accept_license true
   action :reconfigure
 end


### PR DESCRIPTION
This PR add `accept_license` property to chef-ingredient so the users can set it to be able to reconfigure compliance, manage, reporting and analytics after the version that supports `--accept-license` during reconfigure ships. 

@mmzyk note that this PR needs the minimum version numbers that support `--accept-license` CLI option. I have set them to be a minor version bump with the current existing ones. If we would like to set a different version let me know.

/cc: @chef-cookbooks/engineering-services @alexpop 