### PR TITLE
Get rid of default: nil warnings

### DIFF
--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -23,21 +23,21 @@ class Chef
       default_action :install
 
       attribute :product_name, kind_of: String, name_attribute: true
-      attribute :config, kind_of: String, default: nil
+      attribute :config, kind_of: String
 
       # Attributes for determining what version to install from which channel
       attribute :version, kind_of: [String, Symbol], default: :latest
       attribute :channel, kind_of: Symbol, default: :stable, equal_to: [:current, :stable, :unstable]
 
       # Attribute to install package from local file
-      attribute :package_source, kind_of: String, default: nil
+      attribute :package_source, kind_of: String
 
       # Sets the *-ctl command to use when doing reconfigure
       attribute :ctl_command, kind_of: String
 
       # Attributes for package resources used on rhel and debian platforms
       attribute :options, kind_of: String
-      attribute :timeout, kind_of: [Integer, String, NilClass], default: nil
+      attribute :timeout, kind_of: [Integer, String, NilClass]
 
       # Attribute to accept the license when applicable
       attribute :accept_license, kind_of: [TrueClass, FalseClass], default: false

--- a/resources/ingredient_config.rb
+++ b/resources/ingredient_config.rb
@@ -25,7 +25,7 @@ default_action :render
 
 property :product_name, String, name_property: true
 property :sensitive, [TrueClass, FalseClass], default: false
-property :config, [String, NilClass], default: nil
+property :config, [String, NilClass]
 
 action :render do
   target_config = ingredient_config_file(product_name)

--- a/spec/unit/recipes/test_repo_spec.rb
+++ b/spec/unit/recipes/test_repo_spec.rb
@@ -196,7 +196,7 @@ EOS
       installer = instance_double('installer', artifact_info: [])
       allow_any_instance_of(Chef::Provider::ChefIngredient).to receive(:installer).and_return(installer)
 
-      expect { ubuntu_1404 }.to raise_error
+      expect { ubuntu_1404 }.to raise_error RuntimeError, /No package found for 'chef-server' with version 'latest' for current platform in 'stable' channel/
     end
   end
 end


### PR DESCRIPTION
The `default: nil` doesn't actually do anything, but in a world of `nil` setters, it will actively be wrong unless `nil` becomes a valid value for the resource.