### PR TITLE
Remove extraneous converge_by

### DIFF
--- a/libraries/default_handler.rb
+++ b/libraries/default_handler.rb
@@ -100,13 +100,11 @@ Check that the package exists.
       remote_artifact_path = artifact_info.url
       local_artifact_path = File.join(cache_path, ::File.basename(remote_artifact_path))
 
-      converge_by "Download #{new_resource.product_name} package from #{remote_artifact_path}\n" do
-        remote_file local_artifact_path do
-          source remote_artifact_path
-          mode '0644'
-          checksum installer.artifact_info.sha256
-          backup 1
-        end
+      remote_file local_artifact_path do
+        source remote_artifact_path
+        mode '0644'
+        checksum installer.artifact_info.sha256
+        backup 1
       end
 
       configure_from_source_package(action_name, local_artifact_path)


### PR DESCRIPTION
Converge_by is used to say "Here's a thing that is definitely changing",
showing a green entry in the chef run output, marking the resource as changed,
and being skipped in why_run mode.

However, in this case, the thing inside the converge_by is a resource itself
(remote_file), which has all the previous properties. In addition, no testing
is done before the converge_by, meaning a change is registered (and a message
saying 'Downloading X' in green is shown) every time, regardless of whether an
actual file is downloaded by the remote_file resource.

Removing the converge by fixes this behavior, and if a file is actually
downloaded then the remote_file resource will say so with a 'create new file'
message.

Refs #102