### PR TITLE
Added timeout to configure_from_source_package

### DIFF
--- a/libraries/default_handler.rb
+++ b/libraries/default_handler.rb
@@ -48,10 +48,12 @@ module ChefIngredient
     end
 
     def configure_from_source_package(action_name, local_path = nil)
+      # Foodcritic doesn't like timeout attribute in package resource
       package new_resource.product_name do
         action action_name
         package_name ingredient_package_name
         options new_resource.options
+        timeout new_resource.timeout
         source local_path || new_resource.package_source
         provider value_for_platform_family(
           'debian'  => Chef::Provider::Package::Dpkg,


### PR DESCRIPTION
It was previously added to configure_from_repo but apparently missed in the other configure method. I've ran this change in our chef environment without error, although I wasn't able to confirm it was actually using the new timeout (the timeouts we were getting were intermittent, so it may or may not have worked :smile: ).