### PR TITLE
Update SUSE platform to use DefaultHandler

### DIFF
--- a/libraries/chef_ingredient_provider.rb
+++ b/libraries/chef_ingredient_provider.rb
@@ -37,7 +37,7 @@ class Chef
       def initialize(name, run_context = nil)
         super(name, run_context)
         case node['platform_family']
-        when 'debian', 'rhel', 'windows'
+        when 'debian', 'rhel', 'suse', 'windows'
           extend ::ChefIngredient::DefaultHandler
         else
           # OmnitruckHandler is used for Solaris, AIX, FreeBSD, etc.

--- a/libraries/default_handler.rb
+++ b/libraries/default_handler.rb
@@ -56,6 +56,7 @@ module ChefIngredient
         provider value_for_platform_family(
           'debian'  => Chef::Provider::Package::Dpkg,
           'rhel'    => Chef::Provider::Package::Rpm,
+          'suse'    => Chef::Provider::Package::Rpm,
           'windows' => Chef::Provider::Package::Windows
         )
         if new_resource.product_name == 'chef'

--- a/spec/unit/recipes/test_handlers_spec.rb
+++ b/spec/unit/recipes/test_handlers_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'test::handlers' do
+  context 'install chef on aix' do
+    cached(:aix) do
+      ChefSpec::SoloRunner.new(
+        platform: 'aix',
+        version: '7.1',
+        step_into: %w(chef_ingredient)
+      ).converge(described_recipe)
+    end
+
+    it 'use the omnitruck handler' do
+      skip 'chefspec instance mocking issue'
+      expect(aix).to run_execute('install-chef-latest').with(command: 'sudo /bin/sh installer.sh')
+    end
+  end
+
+  context 'install chef on ubuntu' do
+    cached(:ubuntu_1404) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04',
+        step_into: %w(chef_ingredient)
+      ).converge(described_recipe)
+    end
+
+    it 'use the default handler' do
+      expect(ubuntu_1404).to install_package('chef').with(provider: Chef::Provider::Package::Dpkg)
+    end
+  end
+
+  context 'install chef on suse' do
+    cached(:suse) do
+      ChefSpec::SoloRunner.new(
+        platform: 'suse',
+        version: '12.1',
+        step_into: %w(chef_ingredient)
+      ).converge(described_recipe)
+    end
+
+    it 'use the default handler' do
+      expect(suse).to install_package('chef').with(provider: Chef::Provider::Package::Rpm)
+    end
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/handlers.rb
+++ b/test/fixtures/cookbooks/test/recipes/handlers.rb
@@ -1,0 +1,4 @@
+chef_ingredient 'chef' do
+  channel :stable
+  version :latest
+end


### PR DESCRIPTION
### Description
Add SUSE platform to use DefaultHandler (mixlib-install) rather than the OmnitruckHandler.

### Issues Resolved
OmnitruckHandler is currently broken, and we want to use the DefaultHandler whenever possible.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Patrick Wright <patrick@chef.io>