### PR TITLE
Fix issue when a subsequent CCR doesn't fail as expected with OmnitruckHandler

### DIFF
--- a/libraries/omnitruck_handler.rb
+++ b/libraries/omnitruck_handler.rb
@@ -46,14 +46,10 @@ module ChefIngredient
       if windows?
         file installer_script_path do
           content installer.install_command
-          notifies :run, "powershell_script[#{install_command_resource}]", :immediately
         end
 
         powershell_script install_command_resource do
-          # We pass the install code directly, but still depend upon the file to
-          # change before executing the install
           code installer.install_command
-          action :nothing
 
           if new_resource.product_name == 'chef'
             # We define this resource in ChefIngredientProvider
@@ -63,12 +59,10 @@ module ChefIngredient
       else
         file installer_script_path do
           content installer.install_command
-          notifies :run, "execute[#{install_command_resource}]", :immediately
         end
 
         execute install_command_resource do
           command "sudo /bin/sh #{installer_script_path}"
-          action :nothing
 
           if new_resource.product_name == 'chef'
             # We define this resource in ChefIngredientProvider


### PR DESCRIPTION
### Description

Removed `notifies` for `file` resources in OmnitruckHandler. Once we enter the `configure_version` 
method we should be running the install.

I tested this manually since I'm not sure the best way to validate repeated CCR failures with test-kitchen.

### Issues Resolved

Fixes issue where once a CCR fails, and subsquent CCR would not.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Patrick Wright <patrick@chef.io>