### PR TITLE
Depend on the latest compat_resource + cookstyle fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ namespace :style do
     FoodCritic::Rake::LintTask.new(:chef) do |t|
       t.options = {
         fail_tags: ['any'],
-        progress: true
+        progress: true,
       }
     end
   rescue LoadError

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -285,7 +285,7 @@ module ChefIngredientCookbook
           product_name: new_resource.product_name,
           channel: new_resource.channel,
           product_version: new_resource.version,
-          platform_version_compatibility_mode: new_resource.platform_version_compatibility_mode
+          platform_version_compatibility_mode: new_resource.platform_version_compatibility_mode,
         }.tap do |opt|
           opt[:shell_type] = :ps1 if windows?
         end
@@ -333,7 +333,7 @@ module ChefIngredientCookbook
         # We also have a specific case we need to handle for push-client and push-server
         deprecated_product_names = {
           'push-client' => 'push-jobs-client',
-          'push-server' => 'push-jobs-server'
+          'push-server' => 'push-jobs-server',
         }
 
         if deprecated_product_names.keys.include?(new_resource.product_name)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Primitives for managing Chef products and packages'
 
-depends 'compat_resource', '>= 12.10'
+depends 'compat_resource', '>= 12.16.3'
 
 source_url 'https://github.com/chef-cookbooks/chef-ingredient'
 issues_url 'https://github.com/chef-cookbooks/chef-ingredient/issues'


### PR DESCRIPTION
Prior to 12.16.3 we had some bugs in compat_resource that caused a lot of failures on older chef-client releases. We should depend on a working version.