### PR TITLE
Added timeout to package resource created by configure_from_source_package 

### DIFF
--- a/libraries/default_handler.rb
+++ b/libraries/default_handler.rb
@@ -48,11 +48,13 @@ module ChefIngredient
     end
 
     def configure_from_source_package(action_name, local_path = nil)
-      package new_resource.product_name do
+      # Foodcritic doesn't like timeout attribute in package resource
+      package new_resource.product_name do # ~FC009
         action action_name
         package_name ingredient_package_name
         options new_resource.options
         source local_path || new_resource.package_source
+        timeout new_resource.timeout
         provider value_for_platform_family(
           'debian'  => Chef::Provider::Package::Dpkg,
           'rhel'    => Chef::Provider::Package::Rpm,


### PR DESCRIPTION
### Description

windows_package (created during converge by chef_ingredient => package => windows_package) will use the timeout for the install process (defaults to 600).  Attempted this same change in a [previous PR](https://github.com/chef-cookbooks/chef-ingredient/pull/117), but I didn't respond to the maintainer's question in a timely manner and it was closed.  Evidence of how the timeout attribute is used is shown in the links below:

https://github.com/chef-cookbooks/chef-ingredient/blob/master/libraries/default_handler.rb#L60
https://github.com/chef-cookbooks/windows/blob/master/libraries/windows_package.rb#L207
https://github.com/chef-cookbooks/windows/blob/master/libraries/windows_package.rb#L108

After making this change we stopped getting intermittent timeouts while attempting to run the push jobs cookbook, which uses chef_ingredient to install the push jobs client via .msi.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
