### PR TITLE
add platform detail override attributes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -55,4 +55,3 @@ suites:
       - recipe[test::install_git]
       <% end %>
       - recipe[test::chefdk]
-

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ By default, `chef_ingredient` will install using the `packages.chef.io` stable r
 - `package_source`: Full path to a location where the package is located. If present, this file is used for installing the package. Default `nil`.
 - `timeout`: The amount of time (in seconds) to wait to fetch the installer before timing out. Default: default timeout of the Chef package resource - `900` seconds.
 - `accept_license`: A boolean value that specifies if license should be accepted if it is asked for during `reconfigure`action. This option is applicable to only these products: manage, analytics, reporting and compliance. Default: `false`.
+- `platform`: Override the auto-detected platform for which package to install.
+- `platform_version`: Override the auto-detected platform version for which package to install.
+- `architecture`: Override the auto-detected architecture for which package to install.
+- `platform_version_compatibility_mode`: Find closest matching package when platform auto-detection does not find an exact package match in the repository. Default: `false`.
 
 ### omnibus_service
 

--- a/libraries/chef_ingredient_resource.rb
+++ b/libraries/chef_ingredient_resource.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 class Chef
   class Resource
     class ChefIngredient < Chef::Resource::LWRPBase
@@ -27,7 +28,7 @@ class Chef
 
       # Attributes for determining what version to install from which channel
       attribute :version, kind_of: [String, Symbol], default: :latest
-      attribute :channel, kind_of: Symbol, default: :stable, equal_to: [:current, :stable, :unstable]
+      attribute :channel, kind_of: Symbol, default: :stable, equal_to: [:stable, :current, :unstable]
 
       # Attribute to install package from local file
       attribute :package_source, kind_of: String
@@ -45,6 +46,11 @@ class Chef
       # Attribute to enable selecting packages built for earlier versions in
       # platforms that are not yet officially added to Chef support matrix
       attribute :platform_version_compatibility_mode, kind_of: [TrueClass, FalseClass], default: false
+
+      # Atttibutes for configuring a specific platform package
+      attribute :platform, kind_of: String
+      attribute :platform_version, kind_of: String
+      attribute :architecture, kind_of: String
     end
   end
 end

--- a/libraries/default_handler.rb
+++ b/libraries/default_handler.rb
@@ -96,7 +96,7 @@ module ChefIngredient
 
       if artifact_info == []
         raise <<-EOH
-No package found for '#{new_resource.product_name}' with version '#{new_resource.version}' for current platform in '#{new_resource.channel}' channel.
+No package found for '#{new_resource.product_name}' with version '#{new_resource.version}' for platform '#{installer.options.platform}-#{installer.options.platform_version}-#{installer.options.architecture}' in '#{new_resource.channel}' channel.
 Check that the package exists.
         EOH
       end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -290,7 +290,17 @@ module ChefIngredientCookbook
           opt[:shell_type] = :ps1 if windows?
         end
 
-        Mixlib::Install.new(options).detect_platform
+        platform_details = Mixlib::Install.detect_platform
+
+        platform_details.tap do |opt|
+          opt[:platform] = new_resource.platform if new_resource.platform
+          opt[:platform_version] = new_resource.platform_version if new_resource.platform_version
+          opt[:architecture] = new_resource.architecture if new_resource.architecture
+        end
+
+        options.merge!(platform_details)
+
+        Mixlib::Install.new(options)
       end
     end
 

--- a/spec/unit/recipes/test_override_platform_spec.rb
+++ b/spec/unit/recipes/test_override_platform_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'test::override_platform' do
+  context 'install chefdk on ubuntu' do
+    cached(:ubuntu_1404) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04'
+      ).converge(described_recipe)
+    end
+
+    it 'installs chefdk' do
+      expect(ubuntu_1404).to install_chef_ingredient('chefdk').with(platform: 'el', platform_version: '5')
+    end
+  end
+end

--- a/spec/unit/recipes/test_repo_spec.rb
+++ b/spec/unit/recipes/test_repo_spec.rb
@@ -193,10 +193,11 @@ EOS
 
     it 'raises an error' do
       # override before in spec_helper
-      installer = instance_double('installer', artifact_info: [])
+      options = instance_double('options', platform: 'ubuntu', platform_version: '14.04', architecture: 'x86_64')
+      installer = instance_double('installer', artifact_info: [], options: options)
       allow_any_instance_of(Chef::Provider::ChefIngredient).to receive(:installer).and_return(installer)
 
-      expect { ubuntu_1404 }.to raise_error RuntimeError, /No package found for 'chef-server' with version 'latest' for current platform in 'stable' channel/
+      expect { ubuntu_1404 }.to raise_error RuntimeError, /No package found for 'chef-server' with version 'latest' for platform 'ubuntu-14.04-x86_64' in 'stable' channel/
     end
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/override_platform.rb
+++ b/test/fixtures/cookbooks/test/recipes/override_platform.rb
@@ -1,0 +1,5 @@
+chef_ingredient 'chefdk' do
+  platform 'el'
+  platform_version '5'
+  platform_version_compatibility_mode true
+end


### PR DESCRIPTION
Signed-off-by: Patrick Wright <patrick@chef.io>

### Description

Add platform overrides for the chef_ingredient resource. This will allow users to customize specific packages to be installed. Specifically in cases where the auto-detection logic is returning unfavorable results.

Created a basic unit test for the attributes and manually tested a kitchen suite.

### Issues Resolved

JEX-384

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

@schisamo @chef-cookbooks/engineering-services 
