### PR TITLE
Ensure we install mixlib-install >= 2.1.12

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -87,7 +87,7 @@ module ChefIngredientCookbook
             'mixlib-install'
           )
         else
-          install_gem_from_rubygems('mixlib-install', '~> 2.0')
+          install_gem_from_rubygems('mixlib-install', ['~> 2.1', '>= 2.1.12'])
         end
 
         require 'mixlib/install'


### PR DESCRIPTION
This verison of mixlib-install contains an important compat fix related to the recent delivery -> automate package rename:
https://github.com/chef/mixlib-install/pull/177

Signed-off-by: Seth Chisamore <schisamo@chef.io>

/cc @chef-cookbooks/engineering-services 