### PR TITLE
Remove sensitive property for Chef 13 compatibility

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,0 +1,85 @@
+driver:
+  name: dokken
+  privileged: true # because Docker and SystemD/Upstart
+  chef_version: current
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+  data_bags_path: test/fixtures/data_bags
+  deprecations_as_errors: true
+
+verifier:
+  name: inspec
+
+platforms:
+- name: debian-7
+  driver:
+    image: debian:7
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+
+- name: debian-8
+  driver:
+    image: debian:8
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+
+- name: centos-6
+  driver:
+    image: centos:6
+    platform: rhel
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN yum -y install lsof which initscripts net-tools wget net-tools
+
+- name: centos-7
+  driver:
+    image: centos:7
+    platform: rhel
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+      - RUN yum -y install lsof which systemd-sysv initscripts wget net-tools
+
+- name: fedora-latest
+  driver:
+    image: fedora:latest
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+      - RUN dnf -y install which systemd-sysv initscripts wget net-tools
+
+- name: ubuntu-14.04
+  driver:
+    image: ubuntu-upstart:14.04
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+
+- name: ubuntu-16.04
+  driver:
+    image: ubuntu:16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+
+- name: opensuse-leap
+  driver:
+    image: opensuse:leap
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools
+
+suites:
+  - name: default
+    run_list:
+      - recipe[test::install_git]
+      - recipe[test]
+      - recipe[test::repo]

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -78,8 +78,7 @@ platforms:
       - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools
 
 suites:
-  - name: default
+  - name: chefdk
     run_list:
-      - recipe[test::install_git]
       - recipe[test]
-      - recipe[test::repo]
+      - recipe[test::chefdk]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,7 +8,16 @@ provisioner:
   name: chef_zero
   data_bags_path: test/fixtures/data_bags
   deprecations_as_errors: true
+  retry_on_exit_code:
+    - 213
+  max_retries: 1
+  wait_for_retry: 1
+  client_rb:
+    exit_status: :enabled
+    client_fork: false
 
+verifier:
+  name: inspec
 platforms:
   - name: centos-6.8
   - name: centos-7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-# Use Travis's cointainer based infrastructure
-sudo: false
+sudo: required
+dist: trusty
 
 addons:
   apt:
     sources:
-      - chef-stable-precise
+      - chef-stable-trusty
     packages:
       - chefdk
 
@@ -15,13 +15,26 @@ branches:
   only:
     - master
 
-# Ensure we make ChefDK's Ruby the default
+services: docker
+
+env:
+  matrix:
+  - INSTANCE=default-centos-6
+  - INSTANCE=default-centos-7
+  - INSTANCE=default-ubuntu-1404
+  - INSTANCE=default-ubuntu-1604
+
 before_script:
+  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-  - /opt/chefdk/embedded/bin/chef gem install mixlib-versioning
-  - /opt/chefdk/embedded/bin/chef gem install mixlib-install --pre
-script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/cookstyle --version
   - /opt/chefdk/embedded/bin/foodcritic --version
-  - /opt/chefdk/bin/chef exec delivery local all
+
+script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
+
+matrix:
+  include:
+    - script:
+      - /opt/chefdk/bin/chef exec delivery local all
+      env: UNIT_AND_LINT=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ services: docker
 
 env:
   matrix:
-  - INSTANCE=default-centos-6
-  - INSTANCE=default-centos-7
-  - INSTANCE=default-ubuntu-1404
-  - INSTANCE=default-ubuntu-1604
+  - INSTANCE=chefdk-centos-6
+  - INSTANCE=chefdk-centos-7
+  - INSTANCE=chefdk-ubuntu-1404
+  - INSTANCE=chefdk-ubuntu-1604
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,5 +7,4 @@ description 'Primitives for managing Chef products and packages'
 
 source_url 'https://github.com/chef-cookbooks/chef-ingredient'
 issues_url 'https://github.com/chef-cookbooks/chef-ingredient/issues'
-
-chef_version '>= 12.5'
+chef_version '>= 12.5' if respond_to?(:chef_version)

--- a/resources/ingredient_config.rb
+++ b/resources/ingredient_config.rb
@@ -21,7 +21,6 @@ include ChefIngredientCookbook::Helpers
 provides :ingredient_config
 
 property :product_name, String, name_property: true
-property :sensitive, [TrueClass, FalseClass], default: false
 property :config, [String, NilClass]
 
 action :render do

--- a/test/fixtures/cookbooks/test/recipes/chefdk.rb
+++ b/test/fixtures/cookbooks/test/recipes/chefdk.rb
@@ -1,11 +1,13 @@
-chef_ingredient 'chefdk' do
+chef_ingredient 'install old chefdk version' do
+  product_name 'chefdk'
   action :install
   channel :stable
-  version '0.15.16'
+  version '1.1.16'
 end
 
-chef_ingredient 'chefdk' do
+chef_ingredient 'upgrade to newer chefdk version' do
+  product_name 'chefdk'
   action :upgrade
   channel :stable
-  version '0.16.28'
+  version '1.2.22'
 end

--- a/test/integration/chefdk/test_chefdk_spec.rb
+++ b/test/integration/chefdk/test_chefdk_spec.rb
@@ -1,8 +1,6 @@
-require 'spec_helper'
-
 describe 'test::chefdk' do
   it 'chefdk should print a version' do
-    command = if os[:family] == 'windows'
+    command = if os.windows?
                 `C:\\opscode\\chefdk\\bin\\chef --version`
               else
                 `/opt/chefdk/bin/chef --version`

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe 'chef-ingredient::default' do
+context 'chef-ingredient::default' do
   describe package('chef-server-core') do
     it { should be_installed }
   end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,7 +1,0 @@
-require 'serverspec'
-
-if !(RUBY_PLATFORM !~ /mswin|mingw|windows/)
-  set :backend, :winrm
-else
-  set :backend, :exec
-end

--- a/test/integration/local_package_install/assert_local_package_installed_spec.rb
+++ b/test/integration/local_package_install/assert_local_package_installed_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe 'chef-ingredient::default' do
+context 'chef-ingredient::default' do
   describe package('chef-server-core') do
     it { should be_installed }
   end


### PR DESCRIPTION
This is provided by chef-client on all resources now. Including it here
breaks runs on Chef 13. This PR also adds integration testing in Travis CI with kitchen-dokken and converts from Serverspec to InSpec.

Signed-off-by: Tim Smith <tsmith@chef.io>