### PR TITLE
Fix regex style to match cookstyle recommendations.

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -9,16 +9,16 @@
 # end
 
 guard 'rubocop' do
-  watch(%r(attributes\/.+\.rb$))
-  watch(%r(providers\/.+\.rb$))
-  watch(%r(recipes\/.+\.rb$))
-  watch(%r(resources\/.+\.rb$))
+  watch(%r{attributes\/.+\.rb$})
+  watch(%r{providers\/.+\.rb$})
+  watch(%r{recipes\/.+\.rb$})
+  watch(%r{resources\/.+\.rb$})
   watch('metadata.rb')
 end
 
 guard :rspec, cmd: 'chef exec /opt/chefdk/embedded/bin/rspec', all_on_start: false, notification: false do
-  watch(%r(^libraries\/(.+)\.rb$))
-  watch(%r(^spec\/(.+)_spec\.rb$))
-  watch(%r(^(recipes)\/(.+)\.rb$)) { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^libraries\/(.+)\.rb$})
+  watch(%r{^spec\/(.+)_spec\.rb$})
+  watch(%r{^(recipes)\/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb') { 'spec' }
 end

--- a/Guardfile
+++ b/Guardfile
@@ -9,16 +9,16 @@
 # end
 
 guard 'rubocop' do
-  watch(/attributes\/.+\.rb$/)
-  watch(/providers\/.+\.rb$/)
-  watch(/recipes\/.+\.rb$/)
-  watch(/resources\/.+\.rb$/)
+  watch(%r(attributes\/.+\.rb$))
+  watch(%r(providers\/.+\.rb$))
+  watch(%r(recipes\/.+\.rb$))
+  watch(%r(resources\/.+\.rb$))
   watch('metadata.rb')
 end
 
 guard :rspec, cmd: 'chef exec /opt/chefdk/embedded/bin/rspec', all_on_start: false, notification: false do
-  watch(/^libraries\/(.+)\.rb$/)
-  watch(/^spec\/(.+)_spec\.rb$/)
-  watch(/^(recipes)\/(.+)\.rb$/) { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r(^libraries\/(.+)\.rb$))
+  watch(%r(^spec\/(.+)_spec\.rb$))
+  watch(%r(^(recipes)\/(.+)\.rb$)) { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb') { 'spec' }
 end


### PR DESCRIPTION
Signed-off-by: Nathan Cerny <ncerny@gmail.com>

### Description

Cookstyle reports warnings when using // regex syntax.  This updates the Guardfile to %r{} syntax.

### Issues Resolved


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
