### PR TITLE
Remove debian 6 and ubuntu 10 support

### DIFF
--- a/libraries/default_handler.rb
+++ b/libraries/default_handler.rb
@@ -73,7 +73,7 @@ module ChefIngredient
       package new_resource.product_name do # ~FC009
         action action_name
         package_name ingredient_package_name
-        options package_options_with_force
+        options new_resource.options
         timeout new_resource.timeout
 
         # If the latest version is specified, we should not give any version

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -296,27 +296,6 @@ module ChefIngredientCookbook
     end
 
     #
-    # Returns package installer options with any required
-    # options based on platform
-    #
-    def package_options_with_force
-      options = new_resource.options
-
-      # Ubuntu 10.10 and Debian 6 require the `--force-yes` option
-      # for package installs
-      if (platform?('ubuntu') && node['platform_version'] == '10.04') ||
-         (platform?('debian') && node['platform_version'].start_with?('6'))
-        if options.nil?
-          options = '--force-yes'
-        else
-          options << ' --force-yes'
-        end
-      end
-
-      options
-    end
-
-    #
     # Checks the deprecated properties of chef-ingredient and prints warning
     # messages if any of them are being used.
     #

--- a/spec/unit/recipes/test_custom_repo_setup_recipe_spec.rb
+++ b/spec/unit/recipes/test_custom_repo_setup_recipe_spec.rb
@@ -52,44 +52,4 @@ describe 'test::custom_repo_setup_recipe' do
       expect(ubuntu_1404).to include_recipe 'custom_repo::awesome_custom_setup'
     end
   end
-
-  context 'installs packages with apt options on ubuntu 10.04' do
-    cached(:ubuntu_1004) do
-      ChefSpec::SoloRunner.new(
-        platform: 'ubuntu',
-        version: '10.04',
-        step_into: %w(chef_ingredient chef_server_ingredient)
-      ) do |node|
-        node.normal['chef-server-core']['version'] = nil
-      end.converge(described_recipe)
-    end
-
-    it 'installs apt_package[chef-server-core]' do
-      skip
-      pkgres = ubuntu_1004.find_resource('package', 'chef-server')
-      expect(pkgres).to_not be_nil
-      expect(pkgres).to be_a(Chef::Resource::Package)
-      expect(ubuntu_1004).to install_package('chef-server').with(options: '--force-yes')
-    end
-  end
-
-  context 'installs packages with apt options on debian 6' do
-    cached(:debian_605) do
-      ChefSpec::SoloRunner.new(
-        platform: 'debian',
-        version: '6.0.5',
-        step_into: %w(chef_ingredient chef_server_ingredient)
-      ) do |node|
-        node.normal['chef-server-core']['version'] = nil
-      end.converge(described_recipe)
-    end
-
-    it 'installs apt_package[chef-server-core]' do
-      skip
-      pkgres = debian_605.find_resource('package', 'chef-server')
-      expect(pkgres).to_not be_nil
-      expect(pkgres).to be_a(Chef::Resource::Package)
-      expect(debian_605).to install_package('chef-server').with(options: '--force-yes')
-    end
-  end
 end


### PR DESCRIPTION
Signed-off-by: Patrick Wright <patrick@chef.io>

### Description

Debian 6 and Ubuntu 10 are EOL. The latest fauxhai release doesn't recognize these platforms. Time to remove support from chef-ingredient.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
