### PR TITLE
Pessimistically pin mixlib-install to 3.2

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -87,7 +87,7 @@ module ChefIngredientCookbook
             'mixlib-install'
           )
         else
-          install_gem_from_rubygems('mixlib-install', '~> 3')
+          install_gem_from_rubygems('mixlib-install', '~> 3.2')
         end
 
         require 'mixlib/install'


### PR DESCRIPTION
### Description

This change constricts the installation of the mixlib-install gem to ensure that a version is installed that defines the method `::Mixlib::Install::Util::Class#normalize_architecture`.

### Issues Resolved

- fixes https://github.com/chef-cookbooks/chef-ingredient/issues/151

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
