### PR TITLE
Merge Chef Stack resources and helpers

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -78,3 +78,9 @@ suites:
       <% end %>
       - recipe[test]
       - recipe[test::inspec]
+
+  - name: chef_server
+    includes: [ 'ubuntu-16.04' ]
+    run_list:
+      - recipe[test]
+      - recipe[test::chef_server]

--- a/CHEFSTACK.md
+++ b/CHEFSTACK.md
@@ -145,3 +145,4 @@ Installs Chef Automate.
 - Author: Brandon Raabe <brandon.raabe@newcontext.com>
 - Author: Jeremy J. Miller <jm@chef.io>
 - Author: Josh Hudson <jhudson@chef.io>
+- Author: Stephen Lauck <lauck@chef.io>

--- a/CHEFSTACK.md
+++ b/CHEFSTACK.md
@@ -1,0 +1,142 @@
+# chef_stack
+
+Chef stack is a library cookbook that provides custom resources to build and manage your Chef infrastructure.
+
+An accompanying project, [Chef-Services](https//github.com/stephenlauck/chef-services) exists as an example implementation of Chef Stack.
+
+## Custom Resources
+
+Below are the custom resources provided by this cookbook.
+
+### General Properties
+
+These properties exist for all resources
+
+| Name  | Type | Default Value  |  Description  |
+|---|---|---|---|
+| name  | String  | N/A | A name for the resource |
+| channel  | Symbol  | stable  | The channel from our package repository to install. Most of the time you want stable.  |
+| version  | [String,  Symbol]  | latest  | The version of Automate you want to install  |
+| config  | String  |  N/A | The configuration that will be written to the appropriate configuration file for the product.  |
+| accept_license  | [TrueClass, FalseClass]  | false | Do you accept Chef's license agreements.  |
+| platform  | String  | Auto-detected | Use only if you need to over-ride the default platform.  |
+| platform_version  | String  | Auto-detected | Use only if you need to over-ride the default platform.  |
+
+
+### chef_automate
+
+Installs Chef Automate.
+
+#### Properties
+| Name  | Type | Default Value  |  Description  |
+|---|---|---|---|
+| enterprise  | [String,  Array]  | chef | The Enterprise to create in Automate|
+| license  | String  | N/A  | Your license file |  we recommend using the chef_file resource |
+| chef_user  | String  | workflow  | The user you will connect to the Chef server as  |
+| chef_user_pem  | String  |  N/A | The private key of the above Chef user   |
+| validation_pem  | String  |  N/A | The validator key of the Chef org we're connecting to   |
+| builder_pem  | String  |  N/A | The private key of the build nodes |
+
+### chef_backend
+
+#### Properties
+
+| Name  | Type | Default Value  |  Description  |
+|---|---|---|---|
+| bootstrap_node  | String  | N/A | The node we'll bootstrap secrets with. |
+| publish_address  | String  | node['ipaddress']  | The address you want Chef-Backend to listen on. |
+| chef_backend_secrets  | String  | nil  | A location where your secrets are |  we recommend using the chef_file resource. |
+
+### chef_org
+
+#### Properties
+
+
+| Name  | Type | Default Value  |  Description  |
+|---|---|---|---|
+| org  | String  | N/A | The short name of the org. |
+| org_full_name  | String  | node['ipaddress']  | The full name of the org you want to create. |
+| admins  | Array  | N/A  | An array of admins for the org. |
+| users  | Array  | []  | An array of users for the org. |
+| remove_users  | Array  | [] | An array of users to remove from  the org. |
+| key_path  | String  | N/A | Where to store the validator key that is created with the org. |
+
+### chef_user
+
+| Name  | Type | Default Value  |  Description  |
+|---|---|---|---|
+| username  | String  | N/A | The username of the user. |
+| first_name  | String  | N/A  | The first name of the user. |
+| last_name  | Array  | N/A  | The last name of the user. |
+| email  | Array  | []  | N/A  | The users e-mail. |
+| password  | Array  | [] | The users password. |
+| key_path  | String  | N/A | Where to store the users private key that is created with the user. |
+| serveradmin  | [TrueClass,  FalseClass]  | F | Is the user a serveradmin? |
+
+### chef_client
+| Name  | Type | Default Value  | Description  |
+|---|---|---|---|
+| node_name |  String | true | The name of the node. |
+| version | [String, Symbol] | latest | The version of chef-client to install. |
+| chefdk |  [TrueClass, FalseClass] | false | Do you want to install chefdk? |
+| chef_server_url |  [String, Symbol] | local | What is hte Chef server URL to connect to. |
+| ssl_verify | [TrueClass, FalseClass] | true | Validate ssl certificates? |
+| log_location | String | 'STDOUT' | Where to log. |
+| log_level |  Symbol | auto | Log level. |
+| config |  String | | Any configuration for client.rb. |
+| run_list |  Array | | The clients runlist. |
+| environment |  String | | Which Chef Environment the client belongs to. |
+| validation_pem |  String | | The validation pem to validate with. |
+| validation_client_name |  String | | The validation client name. |
+| tags |  [String, Array] |   '' | Any tags for the node. |
+| interval |  Integer |   1800 | The interval to run chef-client on. |
+| splay | Integer |   1800 | The randomization to add to the interval. |
+| data_collector_token | String |  '93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506' | The data collector token to talk to Visibility. |
+| data_collector_url |  String | | The Visibility URL to send data. |
+
+### chef_file
+
+
+| Name  | Type | Default Value  | Description  |
+|---|---|---|---|
+|  filename | String | | The name of the resource. |
+|  source |  String | | The source of the file. |
+|  user |  String |  default 'root' | The owner of the file. |
+|  group |  String |  default 'root' | The group owner of the file. |
+|  mode |  String |  default '0600' | The mode for the file. |
+
+### chef_server
+
+| Name  | Type | Default Value  | Description  |
+|---|---|---|---|
+|  addons |  Hash | | A set of addons to install with the Chef Server. |
+|  data_collector_token | String |  default '93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506' | The data collector token to authenticate with Chef Visiblity. |
+|  data_collector_url |  String | | The URL to connect to Visibility. |
+
+### chef_supermarket
+
+| Name  | Type | Default Value  | Description  |
+|---|---|---|---|
+| chef_server_url |  String |  Chef::Config['chef_server_url'] | The Chef server's URL. |
+| chef_oauth2_app_id |  String |  | The oauth2 app id from the Chef server. |
+| chef_oauth2_secret |  String |  | The oauth2 secret from the Chef server. |
+| chef_oauth2_verify_ssl |  [TrueClass, FalseClass] |  true | Whether to validate SSL certificates. |
+
+### workflow_builder
+
+| Name  | Type | Default Value  | Description  |
+|---|---|---|---|
+| pj_version | [String, Symbol] | :latest | The version of Push-Jobs to install. |
+| chef_user |  String | 'workflow' | The Chef user to authenticate with the Chef Server. |
+| chef_user_pem |  String |  | The private key of the Chef user to authenticate with the Chef Server. |  
+| builder_pem |  String |  | The builder users private key to communicate with Chef Automate. |  
+| chef_fqdn | String |   URI.parse(Chef::Config['chef_server_url']).host | The FQDN of the Chef server. |
+| automate_fqdn | String | | | The FQDN of the automate server. |
+| supermarket_fqdn | String | | The FQDN of the Supermarket server. |
+| job_dispatch_version | String | 'v2' | Which job dispatch version to use. V1 is push-jobs, V2 is SSH runners. |
+| automate_user |  String | 'admin' | What is the Automate user we're connecting to Automate as. |
+| automate_password |  String | | The password for the user above. |
+| automate_enterprise |  String | 'chef' | The Enterprise to connect to. |
+| chef_config_path |  String | '/etc/chef/client.rb' | The config path for chef-client. |
+
+## Contributers

--- a/CHEFSTACK.md
+++ b/CHEFSTACK.md
@@ -143,3 +143,4 @@ Installs Chef Automate.
 - Author: Nathan Cerny <ncerny@chef.io>
 - Author: Andy Dufour <adufour@chef.io>
 - Author: Brandon Raabe <brandon.raabe@newcontext.com>
+- Author: Jeremy J. Miller <jm@chef.io>

--- a/CHEFSTACK.md
+++ b/CHEFSTACK.md
@@ -141,3 +141,4 @@ Installs Chef Automate.
 
 ## Authors
 - Author: Nathan Cerny <ncerny@chef.io>
+- Author: Andy Dufour <adufour@chef.io>

--- a/CHEFSTACK.md
+++ b/CHEFSTACK.md
@@ -139,4 +139,5 @@ Installs Chef Automate.
 | automate_enterprise |  String | 'chef' | The Enterprise to connect to. |
 | chef_config_path |  String | '/etc/chef/client.rb' | The config path for chef-client. |
 
-## Contributers
+## Authors
+- Author: Nathan Cerny <ncerny@chef.io>

--- a/CHEFSTACK.md
+++ b/CHEFSTACK.md
@@ -142,3 +142,4 @@ Installs Chef Automate.
 ## Authors
 - Author: Nathan Cerny <ncerny@chef.io>
 - Author: Andy Dufour <adufour@chef.io>
+- Author: Brandon Raabe <brandon.raabe@newcontext.com>

--- a/CHEFSTACK.md
+++ b/CHEFSTACK.md
@@ -144,3 +144,4 @@ Installs Chef Automate.
 - Author: Andy Dufour <adufour@chef.io>
 - Author: Brandon Raabe <brandon.raabe@newcontext.com>
 - Author: Jeremy J. Miller <jm@chef.io>
+- Author: Josh Hudson <jhudson@chef.io>

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -300,3 +300,27 @@ module ChefIngredientCookbook
     end
   end
 end
+
+#
+# Chef Stack Helpers
+#
+def prefix
+  (platform_family?('windows') ? 'C:/Chef/' : '/etc/chef/')
+end
+
+def ensurekv(config, hash)
+  hash.each do |k, v|
+    if v.is_a?(Symbol)
+      v = v.to_s
+      str = v
+    else
+      str = "'#{v}'"
+    end
+    if config =~ /^ *#{v}.*$/
+      config.sub(/^ *#{v}.*$/, "#{k} #{str}")
+    else
+      config << "\n#{k} #{str}"
+    end
+  end
+  config
+end

--- a/resources/automate.rb
+++ b/resources/automate.rb
@@ -1,0 +1,119 @@
+#
+# Author:: Nathan Cerny <ncerny@chef.io>
+#
+# Cookbook Name:: chef_stack
+# Resource:: automate
+#
+# Copyright 2017 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource_name 'chef_automate'
+default_action :create
+
+property :name, String, name_property: true
+property :channel, Symbol, default: :stable
+property :version, [String, Symbol], default: :latest
+property :config, String, required: true
+property :accept_license, [TrueClass, FalseClass], default: false
+property :enterprise, [String, Array], default: 'chef'
+property :license, String
+property :chef_user, String, default: 'workflow'
+property :chef_user_pem, String, required: true
+property :validation_pem, String, required: true
+property :builder_pem, String, required: true
+property :platform, String
+property :platform_version, String
+
+load_current_value do
+  # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
+  # node.run_state['chef-orgs'] ||= Mixlib::ShellOut.new('chef-server-ctl org-list').run_command.stdout
+  # current_value_does_not_exist! unless node.run_state['chef-orgs'].index(/^#{org}$/)
+end
+
+action :create do
+  # https://github.com/chef/delivery/issues/469
+  new_resource.config << "\ndelivery['chef_server_proxy'] = false" unless new_resource.config.include?('chef_server_proxy')
+
+  # Always make sure user and key provided to resource is at the bottom of the config, overriding duplicates.
+  new_resource.config << "\ndelivery['chef_username'] = '#{new_resource.chef_user}'"
+  new_resource.config << "\ndelivery['chef_private_key'] = '/etc/delivery/#{new_resource.chef_user}.pem'"
+
+  # Hardcode v1 runner search to automate-build-node
+  new_resource.config << "\ndelivery['default_search'] = 'tags:delivery-build-node'"
+
+  chef_ingredient 'automate' do
+    action :upgrade
+    channel new_resource.channel
+    version new_resource.version
+    config new_resource.config
+    accept_license new_resource.accept_license
+    platform new_resource.platform if new_resource.platform
+    platform_version new_resource.platform_version if new_resource.platform_version
+  end
+
+  directory '/etc/delivery'
+  directory '/etc/chef'
+
+  directory '/var/opt/delivery/license/' do
+    recursive true
+  end
+
+  {
+    '/var/opt/delivery/license/delivery.license' => new_resource.license,
+    "/etc/delivery/#{new_resource.chef_user}.pem" => new_resource.chef_user_pem,
+    '/etc/chef/validation.pem' => new_resource.validation_pem,
+    '/etc/delivery/builder_key' => new_resource.builder_pem,
+  }.each do |file, src|
+    chef_file file do
+      source src
+      user 'root'
+      group 'root'
+      mode '0600'
+    end
+  end
+
+  file '/etc/delivery/builder_key.pub' do
+    content lazy { "ssh-rsa #{[OpenSSL::PKey::RSA.new(::File.read('/etc/delivery/builder_key')).to_blob].pack('m0')}" }
+    user 'root'
+    group 'root'
+    mode '0644'
+  end
+
+  directory '/var/opt/delivery/nginx/etc/addon.d/' do
+    recursive true
+  end
+
+  file '/var/opt/delivery/nginx/etc/addon.d/99-installer_internal.conf' do
+    content <<-EOF
+      location /installer {
+        alias /opt/delivery/embedded/service/omnibus-ctl/installer;
+      }
+      EOF
+  end
+
+  ingredient_config 'automate' do
+    notifies :reconfigure, 'chef_ingredient[automate]', :immediately
+  end
+
+  if new_resource.enterprise.is_a?(String)
+    new_resource.enterprise = [new_resource.enterprise]
+    new_resource.enterprise.each do |ent|
+      execute "create enterprise #{ent}" do
+        command "delivery-ctl create-enterprise #{ent} --ssh-pub-key-file=/etc/delivery/builder_key.pub > /etc/delivery/#{ent}.creds"
+        not_if "delivery-ctl list-enterprises --ssh-pub-key-file=/etc/delivery/builder_key.pub | grep -w #{ent}"
+        only_if 'delivery-ctl status'
+      end
+    end
+  end
+end

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -1,0 +1,93 @@
+#
+# Author:: Nathan Cerny <ncerny@chef.io>
+#
+# Cookbook Name:: chef_stack
+# Resource:: backend
+#
+# Copyright 2017 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource_name 'chef_backend'
+default_action :create
+
+property :name, String, name_property: true
+property :channel, Symbol, default: :stable
+property :version, [String, Symbol], default: :latest
+property :config, String, default: ''
+property :accept_license, [TrueClass, FalseClass], default: false
+property :peers, [String, Array], required: true
+property :publish_address, String, default: node['ipaddress']
+property :chef_backend_secrets, String, default: ''
+property :platform, String
+property :platform_version, String
+
+alias :bootstrap_node :peers
+
+load_current_value do
+  # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
+  # current_value_does_not_exist! unless node.run_state['chef-users'].index(/^#{username}$/)
+end
+
+action :create do
+  raise 'Must accept the Chef License agreement before continuing.' unless new_resource.accept_license
+
+  new_resource.config = ensurekv(new_resource.config, publish_address: new_resource.publish_address)
+  chef_ingredient 'chef-backend' do
+    action :upgrade
+    channel new_resource.channel
+    version new_resource.version
+    config new_resource.config # TODO: Figure out why this isn't working in chef-ingredient
+    accept_license new_resource.accept_license
+    platform new_resource.platform if new_resource.platform
+    platform_version new_resource.platform_version if new_resource.platform_version
+  end
+
+  file '/etc/chef-backend/chef-backend.rb' do
+    content new_resource.config
+  end
+
+  chef_file '/etc/chef-backend/chef-backend-secrets.json' do
+    source new_resource.chef_backend_secrets
+    user 'root'
+    group 'root'
+    mode '0600'
+    not_if { new_resource.chef_backend_secrets.empty? }
+  end
+
+  http_retry_count = Chef::Config['http_retry_count']
+  Chef::Config['http_retry_count'] = 0
+  existing_peer = false
+  peers = (new_resource.peers.is_a?(Array) ? new_resource.peers : [new_resource.peers])
+
+  peers.each do |peer|
+    begin
+      Chef::HTTP.new("http://#{peer}:2379").get('/version')
+      existing_peer = peer
+      break
+    rescue
+      next
+    end
+  end
+  Chef::Config['http_retry_count'] = http_retry_count
+
+  execute 'chef-backend-ctl create-cluster --accept-license --yes' do
+    not_if 'chef-backend-ctl cluster-status &> /dev/null'
+    not_if { existing_peer }
+  end
+
+  execute "chef-backend-ctl join-cluster #{existing_peer} --accept-license --yes" do
+    not_if 'chef-backend-ctl cluster-status &> /dev/null'
+    only_if { existing_peer }
+  end
+end

--- a/resources/chef_org.rb
+++ b/resources/chef_org.rb
@@ -1,0 +1,73 @@
+#
+# Author:: Nathan Cerny <ncerny@chef.io>
+#
+# Cookbook Name:: chef_stack
+# Resource:: chef_org
+#
+# Copyright 2017 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource_name 'chef_org'
+default_action :create
+
+property :org, String, name_property: true
+property :org_full_name, String
+property :admins, Array, required: true
+property :users, Array, default: []
+property :remove_users, Array, default: []
+property :key_path, String
+
+load_current_value do
+  node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
+  node.run_state['chef-orgs'] ||= Mixlib::ShellOut.new('chef-server-ctl org-list').run_command.stdout
+  current_value_does_not_exist! unless node.run_state['chef-orgs'].index(/^#{org}$/)
+end
+
+action :create do
+  directory '/etc/opscode/orgs' do
+    owner 'root'
+    group 'root'
+    mode '0700'
+    recursive true
+  end
+
+  org_full_name = (property_is_set?(:org_full_name) ? new_resource.org_full_name : new_resource.org)
+  key = (property_is_set?(:key_path) ? new_resource.key_path : "/etc/opscode/orgs/#{new_resource.org}-validation.pem")
+  execute "create-org-#{new_resource.org}" do
+    retries 10
+    command "chef-server-ctl org-create #{new_resource.org} #{org_full_name} -f #{key}"
+    not_if { node.run_state['chef-orgs'].index(/^#{new_resource.org}$/) }
+  end
+
+  users.each do |user|
+    execute "add-user-#{user}-org-#{new_resource.org}" do
+      command "chef-server-ctl org-user-add #{new_resource.org} #{user}"
+      only_if { node.run_state['chef-users'].index(/^#{user}$/) }
+    end
+  end
+
+  admins.each do |user|
+    execute "add-admin-#{user}-org-#{new_resource.org}" do
+      command "chef-server-ctl org-user-add --admin #{new_resource.org} #{user}"
+      only_if { node.run_state['chef-users'].index(/^#{user}$/) }
+    end
+  end
+
+  remove_users.each do |user|
+    execute "remove-user-#{user}-org-#{new_resource.org}" do
+      command "chef-server-ctl org-user-remove #{new_resource.org} #{user}"
+      only_if { node.run_state['chef-users'].index(/^#{user}$/) }
+    end
+  end
+end

--- a/resources/chef_user.rb
+++ b/resources/chef_user.rb
@@ -1,0 +1,77 @@
+#
+# Author:: Nathan Cerny <ncerny@chef.io>
+#
+# Cookbook Name:: chef_stack
+# Resource:: chef_user
+#
+# Copyright 2017 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource_name 'chef_user'
+default_action :create
+
+property :username, String, name_property: true
+property :first_name, String, required: true
+property :last_name, String, required: true
+property :email, String, required: true
+property :password, String
+property :key_path, String
+property :serveradmin, [TrueClass, FalseClass], default: false
+
+load_current_value do
+  node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
+  current_value_does_not_exist! unless node.run_state['chef-users'].index(/^#{username}$/)
+end
+
+action :create do
+  directory '/etc/opscode/users' do
+    owner 'root'
+    group 'root'
+    mode '0700'
+    recursive true
+  end
+
+  key = (property_is_set?(:key_path) ? new_resource.key_path : "/etc/opscode/users/#{new_resource.username}.pem")
+  password = (property_is_set?(:password) ? new_resource.password : SecureRandom.base64(36))
+  execute "create-user-#{new_resource.username}" do
+    # sensitive true
+    retries 3
+    command "chef-server-ctl user-create #{new_resource.username} #{new_resource.first_name} #{new_resource.last_name} #{new_resource.email} #{password} -f #{key}"
+    not_if { node.run_state['chef-users'].index(/^#{new_resource.username}$/) }
+  end
+
+  ruby_block 'append-user-to-users' do
+    block do
+      node.run_state['chef-users'] << "#{new_resource.username}\n"
+    end
+  end
+  execute "grant-server-admin-#{new_resource.username}" do
+    command "chef-server-ctl grant-server-admin-permissions #{new_resource.username}"
+    only_if { new_resource.serveradmin }
+  end
+end
+
+action :delete do
+  execute "delete-user-#{new_resource.username}" do
+    retries 3
+    command "chef-server-ctl user-delete #{new_resource.username} --yes --remove-from-admin-groups"
+    only_if { node.run_state['chef-users'].index(/^#{new_resource.username}$/) }
+  end
+
+  ruby_block 'delete-user-to-users' do
+    block do
+      node.run_state['chef-users'] = node.run_state['chef-users'].gsub(/#{new_resource.username}\n/, '')
+    end
+  end
+end

--- a/resources/client.rb
+++ b/resources/client.rb
@@ -1,0 +1,164 @@
+#
+# Author:: Nathan Cerny <ncerny@chef.io>
+#
+# Cookbook Name:: chef_stack
+# Resource:: client
+#
+# Copyright 2017 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# rubocop:disable ParenthesesAsGroupedExpression
+
+resource_name 'chef_client'
+default_action :install
+
+property :node_name, String, name_property: true
+property :version, [String, Symbol], default: :latest
+property :chefdk, [TrueClass, FalseClass], default: false
+property :chef_server_url, [String, Symbol], default: :local
+property :ssl_verify, [TrueClass, FalseClass], default: true
+property :log_location, String, default: 'STDOUT'
+property :log_level, Symbol, default: :auto
+property :config, String
+property :run_list, Array
+property :environment, String
+property :validation_pem, String
+property :validation_client_name, String
+property :tags, [String, Array], default: ''
+property :interval, Integer, default: 1800
+property :splay, Integer, default: 1800
+property :data_collector_token, String, default: '93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506'
+property :data_collector_url, String
+property :platform, String
+property :platform_version, String
+
+load_current_value do
+  version Chef::VERSION
+  chef_server_url Chef::Config['chef_server_url']
+  ssl_verify (Chef::Config['ssl_verify_mode'].eql?(:verify_peer) ? true : false)
+  if Chef::Config['log_location'].is_a?(IO)
+    log_location Chef::Config['log_location'].inspect[/#<IO:<(?<stream>.*)>>/, 'stream']
+  else
+    log_location Chef::Config['log_location']
+  end
+  log_level Chef::Config['log_level']
+  if ::File.exist?(::File.join(Chef::Config[:config_d_dir], 'custom.rb'))
+    config ::File.read(::File.join(Chef::Config[:config_d_dir], 'custom.rb'))
+  end
+  run_list node['recipes']
+end
+
+action :install do
+  chef_ingredient 'chef' do
+    action :upgrade
+    version new_resource.version
+    not_if { new_resource.chefdk }
+    platform new_resource.platform if new_resource.platform
+    platform_version new_resource.platform_version if new_resource.platform_version
+  end
+
+  chef_ingredient 'chefdk' do
+    action :upgrade
+    version new_resource.version
+    only_if { new_resource.chefdk }
+    platform new_resource.platform if new_resource.platform
+    platform_version new_resource.platform_version if new_resource.platform_version
+  end
+
+  directory ::File.join(prefix, 'config.d') do
+    mode '0755'
+    recursive true
+  end
+
+  template 'client.rb' do
+    source 'client.rb.erb'
+    path ::File.join(prefix, 'client.rb')
+    cookbook 'chef_stack'
+    mode '0640'
+    variables node_name: new_resource.node_name,
+              chef_server_url: new_resource.chef_server_url,
+              ssl_verify: new_resource.ssl_verify,
+              log_location: new_resource.log_location,
+              log_level: new_resource.log_level,
+              validation_client_name: new_resource.validation_client_name,
+              json_attribs: ::File.join(prefix, 'dna.json'),
+              data_collector_url: new_resource.data_collector_url,
+              data_collector_token: new_resource.data_collector_token
+  end
+
+  rl = {}
+  rl = rl.merge(run_list: new_resource.run_list) if new_resource.run_list
+  rl = rl.merge(environment: new_resource.environment) if new_resource.environment
+  file 'dna.json' do
+    path ::File.join(prefix, 'dna.json')
+    content rl.to_json
+  end
+
+  file 'custom.rb' do
+    path ::File.join(prefix, 'config.d', 'custom.rb')
+    content new_resource.config
+    mode '0640'
+    only_if { new_resource.config }
+  end
+
+  chef_file ::File.join(prefix, 'validation.pem') do
+    source new_resource.validation_pem
+    user 'root'
+    group 'root'
+    mode '0600'
+    not_if { ::File.exist?(::File.join(prefix, 'client.pem')) }
+    only_if { new_resource.property_is_set?(:validation_pem) }
+  end
+end
+
+action :register do
+  execute 'fetch ssl certificates' do
+    command "knife ssl fetch -c #{::File.join(prefix, 'client.rb')}"
+    not_if "knife ssl check -c #{::File.join(prefix, 'client.rb')}"
+  end
+
+  execute 'register with chef-server' do
+    command "chef-client -j #{::File.join(prefix, 'dna.json')}"
+    live_stream true
+    not_if { ::File.exist?(::File.join(prefix, 'client.pem')) }
+  end
+
+  # ruby_block 'update run_list' do
+  #   block do
+  #     rest = Chef::REST.new(Chef::Config[:chef_server_url])
+  #     org = Chef::Config[:chef_server_url].split('/')[-1]
+  #     rest.post("/organizations/#{org}/nodes/#{node['fqdn']}", '{"run_list": [new_resource.run_list]}')
+  #   end
+  #   not_if { new_resource.run_list.eql?(current_resource.run_list) }
+  # end
+
+  file 'delete validation.pem' do
+    action :delete
+    path ::File.join(prefix, 'validation.pem')
+  end
+
+  execute 'add tags to node' do
+    command "knife tag create #{node['fqdn']} #{(tags.is_a?(Array) ? tags.join(' ') : tags)} -c /etc/chef/client.rb -u #{node['fqdn']}"
+    not_if { tags.eql?('') }
+  end
+end
+
+action :run do
+  execute 'chef-client' do
+    live_stream true
+  end
+end
+
+def prefix
+  (platform_family?('windows') ? 'C:/Chef/' : '/etc/chef/')
+end

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -1,0 +1,62 @@
+#
+# Author:: Nathan Cerny <ncerny@chef.io>
+#
+# Cookbook Name:: chef_stack
+# Resource:: file
+#
+# Copyright 2017 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# rubocop:disable Lint/ParenthesesAsGroupedExpression
+
+resource_name 'chef_file'
+default_action :create
+
+property :filename, String, name_property: true
+property :source, String
+property :user, String, default: 'root'
+property :group, String, default: 'root'
+property :mode, String, default: '0600'
+
+load_current_value do
+  current_value_does_not_exist! unless ::File.exist?(filename)
+end
+
+action :create do
+  new_resource.source = (property_is_set?(:source) ? new_resource.source : "cookbook_file://#{new_resource.filename}")
+  if new_resource.source.start_with?('cookbook_file://')
+    src = new_resource.source.split('://')[1].split('::')
+
+    cookbook_file new_resource.filename do
+      source src[-1]
+      cookbook (src.length == 2 ? src[0] : cookbook_name)
+      user new_resource.user
+      group new_resource.group
+      mode new_resource.mode
+    end
+  elsif new_resource.source =~ %r{^[a-zA-Z]*://.*}
+    remote_file new_resource.filename do
+      source new_resource.source
+      user new_resource.user
+      group new_resource.group
+      mode new_resource.mode
+    end
+  else
+    file new_resource.filename do
+      content new_resource.source
+      user new_resource.user
+      group new_resource.group
+      mode new_resource.mode
+    end
+  end
+end

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -1,0 +1,74 @@
+#
+# Author:: Nathan Cerny <ncerny@chef.io>
+#
+# Cookbook Name:: chef_stack
+# Resource:: server
+#
+# Copyright 2017 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource_name 'chef_server'
+default_action :create
+
+property :name, String, name_property: true
+property :channel, Symbol, default: :stable
+property :version, [String, Symbol], default: :latest
+property :config, String, required: true
+property :accept_license, [TrueClass, FalseClass], default: false
+property :addons, Hash
+property :data_collector_token, String, default: '93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506'
+property :data_collector_url, String
+property :platform, String
+property :platform_version, String
+
+load_current_value do
+  # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
+  # current_value_does_not_exist! unless node.run_state['chef-users'].index(/^#{username}$/)
+end
+
+action :create do
+  if new_resource.data_collector_url
+    new_resource.config << "\ndata_collector['root_url'] = '#{new_resource.data_collector_url}'"
+    new_resource.config << "\ndata_collector['token'] = '#{new_resource.data_collector_token}'"
+  end
+  chef_ingredient 'chef-server' do
+    action :upgrade
+    channel new_resource.channel
+    version new_resource.version
+    config new_resource.config
+    accept_license new_resource.accept_license
+    platform new_resource.platform if new_resource.platform
+    platform_version new_resource.platform_version if new_resource.platform_version
+  end
+
+  ingredient_config 'chef-server' do
+    notifies :reconfigure, 'chef_ingredient[chef-server]', :immediately
+  end
+
+  addons.each do |addon, options|
+    chef_ingredient addon do
+      action :upgrade
+      channel options['channel'] || :stable
+      version options['version'] || :latest
+      config options['config'] || ''
+      accept_license new_resource.accept_license
+      platform new_resource.platform if new_resource.platform
+      platform_version new_resource.platform_version if new_resource.platform_version
+    end
+
+    ingredient_config addon do
+      notifies :reconfigure, "chef_ingredient[#{addon}]", :immediately
+    end
+  end
+end

--- a/resources/supermarket.rb
+++ b/resources/supermarket.rb
@@ -1,0 +1,62 @@
+#
+# Author:: Nathan Cerny <ncerny@chef.io>
+#
+# Cookbook Name:: chef_stack
+# Resource:: supermarket
+#
+# Copyright 2017 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource_name 'chef_supermarket'
+default_action :create
+
+property :name, String, name_property: true
+property :channel, Symbol, default: :stable
+property :version, [String, Symbol], default: :latest
+property :config, Hash, default: {}
+property :chef_server_url, String, default: Chef::Config['chef_server_url']
+property :chef_oauth2_app_id, String, required: true
+property :chef_oauth2_secret, String, required: true
+property :chef_oauth2_verify_ssl, [TrueClass, FalseClass], default: true
+property :accept_license, [TrueClass, FalseClass], default: false
+property :platform, String
+property :platform_version, String
+
+load_current_value do
+  # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
+  # current_value_does_not_exist! unless node.run_state['chef-users'].index(/^#{username}$/)
+end
+
+action :create do
+  chef_ingredient 'supermarket' do
+    action :upgrade
+    channel new_resource.channel
+    version new_resource.version
+    config JSON.pretty_generate(
+      new_resource.config.merge(
+        chef_server_url: new_resource.chef_server_url,
+        chef_oauth2_app_id: new_resource.chef_oauth2_app_id,
+        chef_oauth2_secret: new_resource.chef_oauth2_secret,
+        chef_oauth2_verify_ssl: new_resource.chef_oauth2_verify_ssl
+      )
+    )
+    accept_license new_resource.accept_license
+    platform new_resource.platform if new_resource.platform
+    platform_version new_resource.platform_version if new_resource.platform_version
+  end
+
+  ingredient_config 'supermarket' do
+    notifies :reconfigure, 'chef_ingredient[supermarket]', :immediately
+  end
+end

--- a/resources/wf_builder.rb
+++ b/resources/wf_builder.rb
@@ -1,0 +1,290 @@
+#
+# Author:: Nathan Cerny <ncerny@chef.io>
+#
+# Cookbook Name:: chef_stack
+# Resource:: wf_runner
+#
+# Copyright 2017 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource_name 'workflow_builder'
+default_action :create
+
+property :name, String, name_property: true
+property :channel, Symbol, default: :stable
+property :version, [String, Symbol], default: :latest
+property :pj_version, [String, Symbol], default: :latest
+property :accept_license, [TrueClass, FalseClass], default: false
+property :chef_user, String, default: 'workflow'
+property :chef_user_pem, String, required: true
+property :builder_pem, String, required: true
+property :chef_fqdn, String, default: URI.parse(Chef::Config['chef_server_url']).host
+property :automate_fqdn, String, required: true
+property :supermarket_fqdn, String
+property :job_dispatch_version, String, default: 'v2'
+property :automate_user, String, default: 'admin'
+property :automate_password, String
+property :automate_enterprise, String, default: 'chef'
+property :chef_config_path, String, default: '/etc/chef/client.rb'
+property :platform, String
+property :platform_version, String
+
+load_current_value do
+  # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
+  # current_value_does_not_exist! unless node.run_state['chef-users'].index(/^#{username}$/)
+end
+
+action :create do
+  chef_ingredient 'chefdk' do
+    action :upgrade
+    channel new_resource.channel
+    version new_resource.version
+    accept_license new_resource.accept_license
+    platform new_resource.platform if new_resource.platform
+    platform_version new_resource.platform_version if new_resource.platform_version
+  end
+
+  directory '/etc/chef/trusted_certs' do
+    recursive true
+    mode '0755'
+  end
+
+  [
+    new_resource.chef_fqdn,
+    new_resource.automate_fqdn,
+    new_resource.supermarket_fqdn,
+  ].each do |server|
+    execute "fetch ssl cert for #{server}" do
+      command "knife ssl fetch -s https://#{server} -c #{Chef::Config['config_file']}"
+      not_if "knife ssl check -s https://#{server} -c #{Chef::Config['config_file']}"
+      ignore_failure true
+    end
+  end
+
+  execute 'cat /etc/chef/trusted_certs/*.crt >> /opt/chefdk/embedded/ssl/certs/cacert.pem'
+
+  ohai 'reload_passwd' do
+    action :nothing
+    plugin 'etc'
+    ignore_failure true
+  end
+
+  workspace = '/var/opt/delivery/workspace'
+
+  group 'dbuild'
+
+  user 'dbuild' do
+    home workspace
+    group 'dbuild'
+    notifies :reload, 'ohai[reload_passwd]', :immediately
+  end
+
+  %w(.chef bin lib etc).each do |dir|
+    directory "#{workspace}/#{dir}" do
+      mode '0755'
+      owner 'dbuild'
+      group 'dbuild'
+      recursive true
+    end
+  end
+
+  %w(etc .chef).each do |dir|
+    chef_file "#{workspace}/#{dir}/builder_key" do
+      source new_resource.builder_pem
+      mode '0600'
+      user 'root'
+      group 'root'
+    end
+
+    chef_file "#{workspace}/#{dir}/#{chef_user}.pem" do
+      source new_resource.chef_user_pem
+      mode '0600'
+      user 'root'
+      group 'root'
+    end
+  end
+
+  %w(etc/delivery.rb .chef/knife.rb).each do |dir|
+    file "#{workspace}/#{dir}" do
+      content ensurekv(::File.read(new_resource.chef_config_path),
+                       node_name: new_resource.chef_user,
+                       log_location: :STDOUT,
+                       client_key: "#{workspace}/#{dir}/#{new_resource.chef_user}.pem",
+                       trusted_certs_dir: '/etc/chef/trusted_certs')
+      mode '0644'
+      owner 'dbuild'
+      group 'dbuild'
+    end
+  end
+
+  remote_file "#{workspace}/bin/git_ssh" do
+    source "https://#{automate_fqdn}/installer/git-ssh-wrapper"
+    owner 'dbuild'
+    group 'dbuild'
+    mode '0755'
+  end
+
+  remote_file "#{workspace}/bin/delivery-cmd" do
+    source "https://#{automate_fqdn}/installer/delivery-cmd"
+    owner 'root'
+    group 'root'
+    mode '0750'
+  end
+
+  file '/etc/chef/client.pem' do
+    owner 'root'
+    group 'dbuild'
+    mode '0640'
+  end
+
+  file new_resource.chef_config_path do
+    mode '0644'
+  end
+
+  Dir.glob('/etc/chef/trusted_certs/*').each do |fn|
+    file fn do
+      mode '0644'
+    end
+  end
+
+  case new_resource.job_dispatch_version
+  when 'v1'
+    execute 'tag node as legacy build-node' do
+      command "knife tag create #{Chef::Config['node_name']} delivery-build-node -c new_resource.chef_config_path"
+      not_if { node['tags'].include?('delivery-build-node') }
+    end
+
+    directory '/var/log/push-jobs-client' do
+      recursive true
+    end
+
+    chef_ingredient 'push-jobs-client' do
+      version new_resource.pj_version
+    end
+
+    template '/etc/chef/push-jobs-client.rb' do
+      source 'push-jobs-client.rb.erb'
+      notifies :restart, 'service[push-jobs-client]', :delayed
+    end
+
+    if node['init_package'].eql?('systemd')
+      init_template = 'push-jobs-client-systemd'
+      init_file = '/etc/systemd/system/push-jobs-client.service'
+    elsif node['platform_family'].eql?('debian')
+      init_template = 'push-jobs-client-ubuntu-upstart'
+      init_file = '/etc/init/push-jobs-client.conf'
+    elsif node['platform_family'].eql?('rhel')
+      init_template = 'push-jobs-client-rhel-6'
+      init_file = '/etc/rc.d/init.d/push-jobs-client'
+    else
+      raise 'Unsupported platform for build node'
+    end
+
+    remote_file init_file do
+      source "https://#{automate_fqdn}/installer/#{init_template}"
+      mode '0755'
+      notifies :restart, 'service[push-jobs-client]', :delayed
+    end
+
+    service 'push-jobs-client' do
+      action [:enable, :start]
+    end
+  when 'v2'
+    build_user = 'job_runner'
+    home_dir = '/home/job_runner'
+
+    execute 'tag node as job-runner' do
+      command "knife tag create #{Chef::Config['node_name']} delivery-job-runner -c #{new_resource.chef_config_path}"
+      not_if { node['tags'].include?('delivery-job-runner') }
+    end
+
+    user build_user do
+      action [:create, :lock]
+      home home_dir
+    end
+
+    directory home_dir do
+      owner build_user
+      group build_user
+    end
+
+    directory "#{home_dir}/.ssh" do
+      owner build_user
+      group build_user
+      notifies :touch, "file[#{home_dir}/.ssh/authorized_keys]", :immediately
+    end
+
+    file "#{home_dir}/.ssh/authorized_keys" do
+      action :nothing
+    end
+
+    # TODO: Figure out how to auto-detect enterprise
+    ruby_block 'install job runner' do # ~FC014
+      block do
+        ENV['AUTOMATE_PASSWORD'] = new_resource.automate_password
+
+        Mixlib::ShellOut.new("delivery token \
+        -s #{new_resource.automate_fqdn} \
+        -e #{new_resource.automate_enterprise} \
+        -u #{new_resource.automate_user}").run_command
+
+        data = {
+          hostname: new_resource.name,
+          os: node['os'],
+          platform_family: node['platform_family'],
+          platform: node['platform'],
+          platform_version: node['platform_version'],
+        }
+
+        runner = Mixlib::ShellOut.new("delivery api post runners \
+          -d '#{data.to_json}' \
+          -s #{new_resource.automate_fqdn} \
+          -e #{new_resource.automate_enterprise} \
+          -u #{new_resource.automate_user}").run_command
+        ::File.write(::File.join(home_dir, '.ssh/authorized_keys'), JSON.parse(runner.stdout)['openssh_public_key'])
+      end
+      not_if { ::File.read(::File.join(home_dir, '.ssh/authorized_keys')).include?("#{build_user}@#{node['fqdn']}") }
+    end
+
+    file ::File.join('/etc/sudoers.d', build_user) do
+      content <<-EOF
+    #{build_user} ALL=(root) NOPASSWD:/usr/local/bin/delivery-cmd, /bin/ls
+    Defaults:#{build_user} !requiretty
+    Defaults:#{build_user} secure_path = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    EOF
+      mode '0440'
+    end
+
+    directory ::File.join(home_dir, '.ssh') do
+      owner build_user
+      group build_user
+      mode '0700'
+    end
+
+    file ::File.join(home_dir, '.ssh/authorized_keys') do
+      owner build_user
+      group build_user
+      mode '0600'
+    end
+
+    file '/usr/local/bin/delivery-cmd' do
+      content lazy { ::File.read('/var/opt/delivery/workspace/bin/delivery-cmd') }
+      owner 'dbuild'
+      group 'dbuild'
+      mode '0755'
+    end
+  else
+    raise 'Invalid Runner Version'
+  end
+end

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -1,0 +1,41 @@
+# This file managed by Chef.  Do not edit.
+
+chef_server_url "<%= @chef_server_url %>"
+client_fork true
+
+log_level :<%= @log_level %>
+log_location <%= @log_location %>
+
+<%- if @ssl_verify.eql?(true) %>
+verify_api_cert true
+ssl_verify_mode :verify_peer
+<%- else %>
+verify_api_cert false
+ssl_verify_mode :verify_none
+<%- end %>
+
+<%- if @validation_client_name %>
+validation_client_name "<%= @validation_client_name %>"
+<%- end %>
+
+node_name "<%= @node_name %>"
+<%- if @client_key %>
+client_key "<%= @client_key %>"
+<%- end %>
+
+<%- if @json_attribs %>
+json_attribs "<%= @json_attribs %>"
+<%- end %>
+
+<%- if @data_collector_url %>
+data_collector.server_url = '<%= @data_collector_url %>'
+data_collector.token = '<%= @data_collector_token %>'
+<%- end %>
+
+trusted_certs_dir "<%= @trusted_certs_dir || '/etc/chef/trusted_certs' %>"
+
+# Do not crash if a handler is missing / not installed yet
+begin
+rescue NameError => e
+  Chef::Log.error e
+end

--- a/templates/default/push-jobs-client.rb.erb
+++ b/templates/default/push-jobs-client.rb.erb
@@ -1,0 +1,16 @@
+# File managed by Chef. Do not modify.
+
+chef_server_url   "<%= Chef::Config['chef_server_url'] %>"
+node_name "<%= Chef::Config['node_name'] %>"
+allow_unencrypted true
+
+# Chef server connect options
+trusted_certs_dir "/etc/chef/trusted_certs"
+verify_api_cert   true
+ssl_verify_mode   :verify_peer
+whitelist({"chef-client"=>"chef-client",
+         /^delivery-cmd (.+)$/=>"/var/opt/delivery/workspace/bin/delivery-cmd '\\1'"})
+
+# NOTE - if we settle on a daemon provider that captures and timestamps logs,
+#        set this to 'false' to avoid duplicated timestamps in the logs.
+Mixlib::Log::Formatter.show_time = false

--- a/test/fixtures/cookbooks/test/recipes/chef_server.rb
+++ b/test/fixtures/cookbooks/test/recipes/chef_server.rb
@@ -1,0 +1,15 @@
+node.default['chef_server']['fqdn'] = 'localhost'
+
+chef_server node['chef_server']['fqdn'] do
+  version :latest
+  config <<-EOS
+api_fqdn '#{node['chef_server']['fqdn']}'
+oc_id['applications'] = {
+  "supermarket"=>{"redirect_uri"=>"https://supermarket.services.com/auth/chef_oauth2/callback"}
+}
+EOS
+  addons manage: { version: '2.4.3', config: '' },
+         :"push-jobs-server" => { version: '2.1.0', config: '' }
+  accept_license true
+  data_collector_url 'https://automate.services.com/data-collector/v0/' if search(:node, 'name:automate-centos-68', filter_result: { 'name' => ['name'] }) # ~FC003
+end

--- a/test/integration/chef_server/test_chef_server_spec.rb
+++ b/test/integration/chef_server/test_chef_server_spec.rb
@@ -1,0 +1,7 @@
+# describe command('chef-server-ctl test') do
+#   its('exit_status') { should eq 0 }
+# end
+
+describe command('chef-server-ctl status opscode-erchef') do
+  its('stdout') { should match /run: opscode-erchef:/ }
+end


### PR DESCRIPTION
Signed-off-by: Patrick Wright <patrick@chef.io>

### Description

Move chef_stack resources into chef-ingredient
This PR includes the essentials: the resources, templates, helpers and docs

I did not include the test/fixtures/config directory in this PR as no files were created when I ran the chef-services kitchen tests. I didn't dig into this aspect deeply, but looks simple enough to make adjustments.

Please make suggestions for what other comments and references anyone would like to add.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
