### PR TITLE
update chef_ingredient resource timeout property to be chef 13 compliant

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -1,0 +1,18 @@
+driver:
+  name: proxy
+  host: localhost
+  reset_command: "exit 0"
+  port: 5985
+  username: <%= ENV["machine_user"] %>
+  password: <%= ENV["machine_pass"] %>
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: windows-2012R2
+
+suites:
+  - name: inspec
+    run_list:
+      - recipe[test::inspec]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -59,9 +59,20 @@ suites:
 
   - name: chefdk
     <<: *default
-    includes: [ 'ubuntu-14.04', ubuntu-16.04', 'centos-6.8', 'centos-7.3', 'macosx-10.11', 'windows-server-2012r2-standard' ]
+    includes: [ 'ubuntu-14.04', 'ubuntu-16.04', 'centos-6.8', 'centos-7.3', 'macosx-10.11', 'windows-server-2012r2-standard' ]
     run_list:
       <% if ENV['MIXLIB_INSTALL_GIT_REF'] %>
       - recipe[test::install_git]
       <% end %>
+      - recipe[test]
       - recipe[test::chefdk]
+
+  - name: inspec
+    <<: *default
+    includes: [ 'ubuntu-14.04', 'ubuntu-16.04', 'centos-6.8', 'centos-7.3', 'macosx-10.11', 'windows-server-2012r2-standard' ]
+    run_list:
+      <% if ENV['MIXLIB_INSTALL_GIT_REF'] %>
+      - recipe[test::install_git]
+      <% end %>
+      - recipe[test]
+      - recipe[test::inspec]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+environment:
+  machine_user: vagrant
+  machine_pass: vagrant
+  KITCHEN_YAML: .kitchen.appveyor.yml
+
+# Do not build on tags (GitHub only)
+skip_tags: true
+
+#faster cloning
+clone_depth: 1
+
+# Install the latest nightly of ChefDK
+install:
+  - ps: iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current
+  - ps: 'Get-CimInstance win32_operatingsystem -Property Caption, OSArchitecture, Version | fl Caption, OSArchitecture, Version'
+  - ps: $PSVersionTable
+  - c:\opscode\chefdk\bin\chef.bat exec ruby --version
+  - ps: secedit /export /cfg $env:temp/export.cfg
+  - ps: ((get-content $env:temp/export.cfg) -replace ('PasswordComplexity = 1', 'PasswordComplexity = 0')) | Out-File $env:temp/export.cfg
+  - ps: ((get-content $env:temp/export.cfg) -replace ('MinimumPasswordLength = 8', 'MinimumPasswordLength = 0')) | Out-File $env:temp/export.cfg
+  - ps: secedit /configure /db $env:windir/security/new.sdb /cfg $env:temp/export.cfg /areas SECURITYPOLICY
+  - ps: net user /add $env:machine_user $env:machine_pass
+  - ps: net localgroup administrators $env:machine_user /add
+
+build_script:
+  - ps: c:\opscode\chefdk\bin\chef.bat shell-init powershell | iex; cmd /c c:\opscode\chefdk\bin\chef.bat --version
+
+test_script:
+  - c:\opscode\chefdk\bin\cookstyle --version
+  - c:\opscode\chefdk\bin\chef.bat exec foodcritic --version
+  - c:\opscode\chefdk\bin\chef.bat exec delivery local all
+  - c:\opscode\chefdk\bin\chef.bat exec kitchen verify
+
+deploy: off

--- a/libraries/default_handler.rb
+++ b/libraries/default_handler.rb
@@ -36,6 +36,9 @@ module ChefIngredient
     private
 
     def configure_package(action_name)
+      # Set action name to :install when Windows :upgrade
+      action_name = :install if action_name == :upgrade && windows?
+
       if new_resource.package_source
         configure_from_source_package(action_name)
       elsif use_custom_repo_recipe?
@@ -54,7 +57,7 @@ module ChefIngredient
         package_name ingredient_package_name
         options new_resource.options
         source local_path || new_resource.package_source
-        timeout new_resource.timeout
+        timeout new_resource.timeout if new_resource.timeout
         provider value_for_platform_family(
           'debian'  => Chef::Provider::Package::Dpkg,
           'rhel'    => Chef::Provider::Package::Rpm,
@@ -74,7 +77,7 @@ module ChefIngredient
         action action_name
         package_name ingredient_package_name
         options new_resource.options
-        timeout new_resource.timeout
+        timeout new_resource.timeout if new_resource.timeout
 
         # If the latest version is specified, we should not give any version
         # to the package resource.

--- a/resources/chef_ingredient.rb
+++ b/resources/chef_ingredient.rb
@@ -20,34 +20,35 @@ resource_name :chef_ingredient
 
 default_action :install
 
-property :product_name, kind_of: String, name_attribute: true
-property :config, kind_of: String
+property :product_name, String, name_property: true
+property :config, String
 
 # Determine what version to install from which channel
-property :version, kind_of: [String, Symbol], default: :latest
-property :channel, kind_of: Symbol, default: :stable, equal_to: [:stable, :current, :unstable]
+property :version, [String, Symbol], default: :latest
+property :channel, Symbol, default: :stable, equal_to: [:stable, :current, :unstable]
 
 # Install package from local file
-property :package_source, kind_of: String
+property :package_source, String
 
 # Set the *-ctl command to use when doing reconfigure
-property :ctl_command, kind_of: String
+property :ctl_command, String
 
 # Package resources used on rhel and debian platforms
-property :options, kind_of: String
-property :timeout, kind_of: [Integer, String, NilClass]
+property :options, String
+
+property :timeout, [Integer, String]
 
 # Accept the license when applicable
-property :accept_license, kind_of: [TrueClass, FalseClass], default: false
+property :accept_license, [true, false], default: false
 
 # Enable selecting packages built for earlier versions in
 # platforms that are not yet officially added to Chef support matrix
-property :platform_version_compatibility_mode, kind_of: [TrueClass, FalseClass]
+property :platform_version_compatibility_mode, [true, false]
 
 # Configure specific platform package
-property :platform, kind_of: String
-property :platform_version, kind_of: String
-property :architecture, kind_of: String
+property :platform, String
+property :platform_version, String
+property :architecture, String
 
 platform_family = node['platform_family']
 

--- a/test/fixtures/cookbooks/test/recipes/chefdk.rb
+++ b/test/fixtures/cookbooks/test/recipes/chefdk.rb
@@ -1,13 +1,11 @@
 chef_ingredient 'install old chefdk version' do
   product_name 'chefdk'
   action :install
-  channel :stable
   version '1.1.16'
 end
 
 chef_ingredient 'upgrade to newer chefdk version' do
   product_name 'chefdk'
   action :upgrade
-  channel :stable
   version '1.2.22'
 end

--- a/test/fixtures/cookbooks/test/recipes/inspec.rb
+++ b/test/fixtures/cookbooks/test/recipes/inspec.rb
@@ -1,0 +1,12 @@
+chef_ingredient 'install old inspec version' do
+  product_name 'inspec'
+  version '1.19.2'
+  platform_version_compatibility_mode true
+end
+
+chef_ingredient 'upgrade to newer inspec version' do
+  product_name 'inspec'
+  action :upgrade
+  version '1.20.0'
+  platform_version_compatibility_mode true
+end

--- a/test/integration/chefdk/test_chefdk_spec.rb
+++ b/test/integration/chefdk/test_chefdk_spec.rb
@@ -1,11 +1,5 @@
-describe 'test::chefdk' do
-  it 'chefdk should print a version' do
-    command = if os.windows?
-                `C:\\opscode\\chefdk\\bin\\chef --version`
-              else
-                `/opt/chefdk/bin/chef --version`
-              end
+resource_command = os.windows? ? 'powershell' : 'command'
 
-    expect(command).to include('Chef Development Kit Version:')
-  end
+describe send(resource_command, 'chef --version') do
+  its('stdout') { should match /Chef Development Kit Version: 1.2.22/ }
 end

--- a/test/integration/inspec/inspec_spec.rb
+++ b/test/integration/inspec/inspec_spec.rb
@@ -1,0 +1,18 @@
+# The way this spec is written is more of an experiment. Executing Windows programs for the first time
+# via inspec require the fully qualified path. Even though the bin has been added to $env:Path the session
+# has not been reloaded. This reloads $env:Path before calling the program. I could see this being beneficial to
+# inspec's default behavior.
+
+resource_command = 'command'
+
+if os.windows?
+  resource_command = 'powershell'
+
+  describe powershell('$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")') do
+    its('exit_status') { should eq 0 }
+  end
+end
+
+describe send(resource_command, 'inspec --version') do
+  its('stdout') { should match /1.20.0/ }
+end


### PR DESCRIPTION
Signed-off-by: Patrick Wright <patrick@chef.io>

### Description

chef_ingredient packages installs break on Windows using Chef 13. This fixes the issue and updates tests.

### Issues Resolved

#155 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
