### PR TITLE
remove #check_deprecated_properties

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -298,33 +298,5 @@ module ChefIngredientCookbook
         Mixlib::Install.new(options)
       end
     end
-
-    #
-    # Checks the deprecated properties of chef-ingredient and prints warning
-    # messages if any of them are being used.
-    #
-    def check_deprecated_properties
-      # Historically we have had chef- and opscode- in front of most of our
-      # packages. We have standardized on names without any prefixes except some products.
-      if !%w(chef-backend chef-server chef-server-ha-provisioning).include?(new_resource.product_name) &&
-         (match = new_resource.product_name.match(/(chef-|opscode-)(?<product_key>.*)/))
-
-        new_product_key = match[:product_key]
-        Chef::Log.warn "product_name '#{new_resource.product_name}' is deprecated and it will be removed in the future versions of chef-ingredient. Use '#{new_product_key}' instead of '#{new_resource.product_name}'."
-        new_resource.product_name(new_product_key)
-      else
-        # We also have a specific case we need to handle for push-client and push-server
-        deprecated_product_names = {
-          'push-client' => 'push-jobs-client',
-          'push-server' => 'push-jobs-server',
-        }
-
-        if deprecated_product_names.keys.include?(new_resource.product_name)
-          new_product_key = deprecated_product_names[new_resource.product_name]
-          Chef::Log.warn "product_name '#{new_resource.product_name}' is deprecated and it will be removed in the future versions of chef-ingredient. Use '#{new_product_key}' instead of '#{new_resource.product_name}'."
-          new_resource.product_name(new_product_key)
-        end
-      end
-    end
   end
 end

--- a/resources/chef_ingredient.rb
+++ b/resources/chef_ingredient.rb
@@ -53,7 +53,6 @@ property :architecture, String
 platform_family = node['platform_family']
 
 action :install do
-  check_deprecated_properties
   add_config(new_resource.product_name, new_resource.config)
   declare_chef_run_stop_resource
 
@@ -61,7 +60,6 @@ action :install do
 end
 
 action :upgrade do
-  check_deprecated_properties
   add_config(new_resource.product_name, new_resource.config)
   declare_chef_run_stop_resource
 
@@ -69,12 +67,10 @@ action :upgrade do
 end
 
 action :uninstall do
-  check_deprecated_properties
   handle_uninstall
 end
 
 action :reconfigure do
-  check_deprecated_properties
   add_config(new_resource.product_name, new_resource.config)
 
   if ingredient_ctl_command.nil?


### PR DESCRIPTION
Signed-off-by: Patrick Wright <patrick@chef.io>

### Description

This logic is not necessary. I believe it was there pre-mixlib-install. Now, mixlib-install handles verifying the product name and returning valid products. 

@iennae This should make things easier :)

@chef-cookbooks/engineering-services 

### Issues Resolved

#158 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
