### PR TITLE
Reinstate mixlib install platform mapping logic

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -270,10 +270,15 @@ module ChefIngredientCookbook
       @installer ||= begin
         ensure_mixlib_install_gem_installed!
 
+        resolve_platform_properties!
+
         options = {
           product_name: new_resource.product_name,
           channel: new_resource.channel,
           product_version: new_resource.version,
+          platform: new_resource.platform,
+          platform_version: new_resource.platform_version,
+          architecture: new_resource.architecture,
         }.tap do |opt|
           if new_resource.platform_version_compatibility_mode
             opt[:platform_version_compatibility_mode] = new_resource.platform_version_compatibility_mode
@@ -281,16 +286,32 @@ module ChefIngredientCookbook
           opt[:shell_type] = :ps1 if windows?
         end
 
-        platform_details = {
-          platform: platform_family_shortname,
-          platform_version: truncate_platform_version(new_resource.platform_version, new_resource.platform),
-          architecture: Mixlib::Install::Util.normalize_architecture(new_resource.architecture),
-        }
-
-        options.merge!(platform_details)
-
         Mixlib::Install.new(options)
       end
+    end
+
+    #
+    # Defaults platform, platform_version, and architecture
+    # properties when not set by recipe
+    #
+    def resolve_platform_properties!
+      # Auto detect platform
+      detected_platform = Mixlib::Install.detect_platform
+
+      if new_resource.platform.nil?
+        new_resource.platform(detected_platform[:platform])
+      end
+
+      if new_resource.platform_version.nil?
+        new_resource.platform_version(detected_platform[:platform_version])
+      end
+
+      if new_resource.architecture.nil?
+        architecture = Mixlib::Install::Util.normalize_architecture(detected_platform[:architecture])
+        new_resource.architecture(architecture)
+      end
+
+      true
     end
 
     def prefix
@@ -312,99 +333,6 @@ module ChefIngredientCookbook
         end
       end
       config
-    end
-
-    #
-    # TODO: Imported from Omnibus::Metadata
-    # Will be moved into a Mixlib Install module
-    #
-
-    #
-    # Platform name to be used when creating metadata for the artifact.
-    #
-    # @return [String]
-    #   the platform family short name
-    #
-    def platform_family_shortname
-      if platform_family?('rhel')
-        'el'
-      elsif platform_family?('suse')
-        'sles'
-      else
-        new_resource.platform
-      end
-    end
-
-    #
-    # TODO: Imported from Omnibus::Metadata
-    # Will be moved into a Mixlib Install module
-    #
-
-    #
-    # On certain platforms we don't care about the full MAJOR.MINOR.PATCH platform
-    # version. This method will properly truncate the version down to a more human
-    # friendly version. This version can also be thought of as a 'marketing'
-    # version.
-    #
-    # @param [String] platform_version
-    #   the platform version to truncate
-    # @param [String] platform
-    #   the platform shortname. this might be an Ohai-returned platform or
-    #   platform family but it also might be a shortname like `el`
-    #
-    def truncate_platform_version(platform_version, platform)
-      case platform
-      when 'centos', 'debian', 'el', 'fedora', 'freebsd', 'omnios', 'pidora', 'raspbian', 'rhel', 'sles', 'suse', 'smartos', 'nexus', 'ios_xr' # ~FC024
-        # Only want MAJOR (e.g. Debian 7, OmniOS r151006, SmartOS 20120809T221258Z)
-        platform_version.split('.').first
-      when 'aix', 'alpine', 'gentoo', 'mac_os_x', 'openbsd', 'slackware', 'solaris2', 'opensuse', 'ubuntu'
-        # Only want MAJOR.MINOR (e.g. Mac OS X 10.9, Ubuntu 12.04)
-        platform_version.split('.')[0..1].join('.')
-      when 'arch'
-        # Arch Linux does not have a platform_version ohai attribute, it is rolling release (lsb_release -r)
-        'rolling'
-      when 'windows'
-        # Windows has this really awesome "feature", where their version numbers
-        # internally do not match the "marketing" name.
-        #
-        # Definitively computing the Windows marketing name actually takes more
-        # than the platform version. Take a look at the following file for the
-        # details:
-        #
-        #   https://github.com/opscode/chef/blob/master/lib/chef/win32/version.rb
-        #
-        # As we don't need to be exact here the simple mapping below is based on:
-        #
-        #  http://www.jrsoftware.org/ishelp/index.php?topic=winvernotes
-        #
-        # Microsoft's version listing (more general than the above) is here:
-        #
-        # https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx
-        #
-        case platform_version
-        when '5.0.2195', '2000'   then '2000'
-        when '5.1.2600', 'xp'     then 'xp'
-        when '5.2.3790', '2003r2' then '2003r2'
-        when '6.0.6001', '2008'   then '2008'
-        when '6.1.7600', '7'      then '7'
-        when '6.1.7601', '2008r2' then '2008r2'
-        when '6.2.9200', '2012'   then '2012'
-        # The following `when` will never match since Windows 8's platform
-        # version is the same as Windows 2012. It's only here for completeness and
-        # documentation.
-        # when '6.2.9200', '8'      then '8'
-        when /6\.3\.\d+/, '2012r2' then '2012r2'
-        # The following `when` will never match since Windows 8.1's platform
-        # version is the same as Windows 2012R2. It's only here for completeness
-        # and documentation.
-        # when /6\.3\.\d+/, '8.1' then '8.1'
-        when /^10\.0/ then '10'
-        else
-          raise "Unknown Platform Version: #{platform} #{platform_version}"
-        end
-      else
-        raise "Unknown Platform #{platform}"
-      end
     end
   end
 end

--- a/resources/chef_ingredient.rb
+++ b/resources/chef_ingredient.rb
@@ -46,9 +46,9 @@ property :accept_license, [true, false], default: false
 property :platform_version_compatibility_mode, [true, false]
 
 # Configure specific platform package
-property :platform, String, default: node['platform']
-property :platform_version, String, default: node['platform_version']
-property :architecture, String, default: node['kernel']['machine']
+property :platform, String
+property :platform_version, String
+property :architecture, String
 
 platform_family = node['platform_family']
 


### PR DESCRIPTION
- Remove logic ported from omnibus
- Remove default values from platform-related properties
- Reinstate Mixlib Install platform detection
- Never modify platform-related properties when explicity set
- Auto-detect and set platform-related properties when not explicity set

Signed-off-by: Patrick Wright <patrick@chef.io>

### Description

[Describe what this change achieves]

### Issues Resolved

#168

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
