### PR TITLE
(wip) adding package_source support to new constructs

### DIFF
--- a/resources/automate.rb
+++ b/resources/automate.rb
@@ -34,6 +34,7 @@ property :validation_pem, String, required: true
 property :builder_pem, String, required: true
 property :platform, String
 property :platform_version, String
+property :package_source, String
 
 load_current_value do
   # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
@@ -57,6 +58,7 @@ action :create do
     accept_license new_resource.accept_license
     platform new_resource.platform if new_resource.platform
     platform_version new_resource.platform_version if new_resource.platform_version
+    package_source new_resource.package_source if new_resource.package_source
   end
 
   %w(/etc/delivery /etc/chef /var/opt/delivery/license).each do |dir|

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -31,6 +31,7 @@ property :publish_address, String, default: node['ipaddress']
 property :chef_backend_secrets, String, default: ''
 property :platform, String
 property :platform_version, String
+property :package_source, String
 
 alias :bootstrap_node :peers
 
@@ -51,6 +52,7 @@ action :create do
     accept_license new_resource.accept_license
     platform new_resource.platform if new_resource.platform
     platform_version new_resource.platform_version if new_resource.platform_version
+    package_source new_resource.package_source if new_resource.package_source
   end
 
   file '/etc/chef-backend/chef-backend.rb' do

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -26,7 +26,7 @@ property :channel, Symbol, default: :stable
 property :version, [String, Symbol], default: :latest
 property :config, String, required: true
 property :accept_license, [TrueClass, FalseClass], default: false
-property :addons, Hash, default: nil
+property :addons, Hash
 property :data_collector_token, String, default: '93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506'
 property :data_collector_url, String
 property :platform, String
@@ -73,7 +73,7 @@ action :create do
     ingredient_config addon do
       notifies :reconfigure, "chef_ingredient[#{addon}]", :immediately
     end
-  end #if new_resource.addons
+  end
 end
 
 action_class.class_eval do

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -26,7 +26,7 @@ property :channel, Symbol, default: :stable
 property :version, [String, Symbol], default: :latest
 property :config, String, required: true
 property :accept_license, [TrueClass, FalseClass], default: false
-property :addons, Hash
+property :addons, Hash, default: nil
 property :data_collector_token, String, default: '93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506'
 property :data_collector_url, String
 property :platform, String
@@ -73,7 +73,7 @@ action :create do
     ingredient_config addon do
       notifies :reconfigure, "chef_ingredient[#{addon}]", :immediately
     end
-  end
+  end #if new_resource.addons
 end
 
 action_class.class_eval do

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -31,6 +31,7 @@ property :data_collector_token, String, default: '93a49a4f2482c64126f7b6015e6b0f
 property :data_collector_url, String
 property :platform, String
 property :platform_version, String
+property :package_source, String
 
 load_current_value do
   # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
@@ -50,6 +51,7 @@ action :create do
     accept_license new_resource.accept_license
     platform new_resource.platform if new_resource.platform
     platform_version new_resource.platform_version if new_resource.platform_version
+    package_source new_resource.package_source if new_resource.package_source
   end
 
   ingredient_config 'chef-server' do
@@ -65,6 +67,7 @@ action :create do
       accept_license new_resource.accept_license
       platform new_resource.platform if new_resource.platform
       platform_version new_resource.platform_version if new_resource.platform_version
+      package_source new_resource.package_source if new_resource.package_source
     end
 
     ingredient_config addon do

--- a/resources/supermarket.rb
+++ b/resources/supermarket.rb
@@ -32,6 +32,7 @@ property :chef_oauth2_verify_ssl, [TrueClass, FalseClass], default: true
 property :accept_license, [TrueClass, FalseClass], default: false
 property :platform, String
 property :platform_version, String
+property :package_source, String
 
 load_current_value do
   # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
@@ -54,6 +55,7 @@ action :create do
     accept_license new_resource.accept_license
     platform new_resource.platform if new_resource.platform
     platform_version new_resource.platform_version if new_resource.platform_version
+    package_source new_resource.package_source if new_resource.package_source
   end
 
   ingredient_config 'supermarket' do


### PR DESCRIPTION
### Description

Adding package_source pass-through to chef-server, supermarket, backend, and automate resources. This will pass package_source to the chef_ingredient resource, allowing installation of components in an off-public-facing-internet environment.

### Issues Resolved

https://github.com/chef-cookbooks/chef-ingredient/issues/171
Not included: chef-client and wf_builder

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
