### PR TITLE
(wip) stab at skipping addons if none are defined

### DIFF
--- a/resources/server.rb
+++ b/resources/server.rb
@@ -26,7 +26,7 @@ property :channel, Symbol, default: :stable
 property :version, [String, Symbol], default: :latest
 property :config, String, required: true
 property :accept_license, [TrueClass, FalseClass], default: false
-property :addons, Hash
+property :addons, Hash, default: lazy { {} }
 property :data_collector_token, String, default: '93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506'
 property :data_collector_url, String
 property :platform, String


### PR DESCRIPTION
Signed-off-by: Alex Vinyar <alex@getchef.com>

### Description

chef_server (server.rb) resource fails with Nil error if no addons are defined.

### Issues Resolved
https://github.com/chef-cookbooks/chef-ingredient/issues/176

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
