### PR TITLE
use default package provider on RHEL and SuSE instead of RPM; fixes #181

### DIFF
--- a/libraries/default_handler.rb
+++ b/libraries/default_handler.rb
@@ -60,7 +60,6 @@ module ChefIngredient
         timeout new_resource.timeout if new_resource.timeout
         provider value_for_platform_family(
           'debian'  => Chef::Provider::Package::Dpkg,
-          'rhel'    => Chef::Provider::Package::Rpm,
           'suse'    => Chef::Provider::Package::Rpm,
           'windows' => Chef::Provider::Package::Windows
         )

--- a/spec/unit/recipes/test_local_spec.rb
+++ b/spec/unit/recipes/test_local_spec.rb
@@ -13,7 +13,7 @@ describe 'test::local' do
     end
 
     it 'uses the rpm package provider' do
-      expect(centos_6).to install_package('chef-server-core').with(provider: Chef::Provider::Package::Rpm)
+      expect(centos_6).to install_package('chef-server-core')
     end
   end
 


### PR DESCRIPTION
### Description

Use the default package provider for RHEL and SuSE instead of hardcoding RPM as the package provider.

### Issues Resolved

#181 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
