### PR TITLE
Update chef_org resource to fix deprecation warnings

### DIFF
--- a/resources/chef_org.rb
+++ b/resources/chef_org.rb
@@ -50,21 +50,21 @@ action :create do
     not_if { node.run_state['chef-orgs'].index(/^#{new_resource.org}$/) }
   end
 
-  users.each do |user|
+  new_resource.users.each do |user|
     execute "add-user-#{user}-org-#{new_resource.org}" do
       command "chef-server-ctl org-user-add #{new_resource.org} #{user}"
       only_if { node.run_state['chef-users'].index(/^#{user}$/) }
     end
   end
 
-  admins.each do |user|
+  new_resource.admins.each do |user|
     execute "add-admin-#{user}-org-#{new_resource.org}" do
       command "chef-server-ctl org-user-add --admin #{new_resource.org} #{user}"
       only_if { node.run_state['chef-users'].index(/^#{user}$/) }
     end
   end
 
-  remove_users.each do |user|
+  current_resource.remove_users.each do |user|
     execute "remove-user-#{user}-org-#{new_resource.org}" do
       command "chef-server-ctl org-user-remove #{new_resource.org} #{user}"
       only_if { node.run_state['chef-users'].index(/^#{user}$/) }


### PR DESCRIPTION
…s, and remove_users.

### Description

fix deprecation warnings for chef_org resource.

### Issues Resolved

>          rename users to current_resource.users at 1 location:
>            - /tmp/kitchen/cache/cookbooks/chef-ingredient/resources/chef_org.rb:53:in `block in class_from_file'
>           See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
>          rename admins to new_resource.admins at 1 location:
>            - /tmp/kitchen/cache/cookbooks/chef-ingredient/resources/chef_org.rb:60:in `block in class_from_file'
>           See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
>          rename remove_users to current_resource.remove_users at 1 location:
>            - /tmp/kitchen/cache/cookbooks/chef-ingredient/resources/chef_org.rb:67:in `block in class_from_file'
>           See https://docs.chef.io/deprecations_namespace_collisions.html for further details.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
