### PR TITLE
RHEL 5 and 6 package manager support

### DIFF
--- a/libraries/default_handler.rb
+++ b/libraries/default_handler.rb
@@ -60,6 +60,7 @@ module ChefIngredient
         timeout new_resource.timeout if new_resource.timeout
         provider value_for_platform_family(
           'debian'  => Chef::Provider::Package::Dpkg,
+          'rhel'    => node['platform_version'].to_i == 5 ? Chef::Provider::Package::Rpm : Chef::Provider::Package::Yum,
           'suse'    => Chef::Provider::Package::Rpm,
           'windows' => Chef::Provider::Package::Windows
         )

--- a/spec/unit/recipes/test_default_handler_spec.rb
+++ b/spec/unit/recipes/test_default_handler_spec.rb
@@ -28,4 +28,32 @@ describe 'test::default_handler' do
       expect(suse).to install_package('chef').with(provider: Chef::Provider::Package::Rpm)
     end
   end
+
+  context 'install chef on rhel 5' do
+    let(:rhel_5) do
+      ChefSpec::SoloRunner.new(
+        platform: 'redhat',
+        version: '5.10',
+        step_into: %w(chef_ingredient)
+      ).converge(described_recipe)
+    end
+
+    it 'use the RPM package provider' do
+      expect(rhel_5).to install_package('chef').with(provider: Chef::Provider::Package::Rpm)
+    end
+  end
+
+  context 'install chef on rhel 6' do
+    let(:rhel_6) do
+      ChefSpec::SoloRunner.new(
+        platform: 'redhat',
+        version: '6.9',
+        step_into: %w(chef_ingredient)
+      ).converge(described_recipe)
+    end
+
+    it 'use the Yum package provider' do
+      expect(rhel_6).to install_package('chef').with(provider: Chef::Provider::Package::Yum)
+    end
+  end
 end

--- a/spec/unit/recipes/test_local_spec.rb
+++ b/spec/unit/recipes/test_local_spec.rb
@@ -12,8 +12,8 @@ describe 'test::local' do
       end.converge(described_recipe)
     end
 
-    it 'uses the rpm package provider' do
-      expect(centos_6).to install_package('chef-server-core')
+    it 'uses the Yum package provider' do
+      expect(centos_6).to install_package('chef-server-core').with(provider: Chef::Provider::Package::Yum)
     end
   end
 


### PR DESCRIPTION
### Description

Engineering Services requires RHEL 5 builder support.

@chef-cookbooks/engineering-services 

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
