### PR TITLE
Update centos version to '6.8' in specs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -84,3 +84,9 @@ suites:
     run_list:
       - recipe[test]
       - recipe[test::chef_server]
+
+  - name: automate
+    includes: [ 'ubuntu-16.04' ]
+    run_list:
+      - recipe[test]
+      - recipe[test::automate]

--- a/spec/unit/recipes/test_config_spec.rb
+++ b/spec/unit/recipes/test_config_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'test::config' do
   [
     { platform: 'ubuntu', version: '14.04' },
-    { platform: 'centos', version: '6.9' },
+    { platform: 'centos', version: '6.8' },
   ].each do |platform|
     context "non-platform specific resources on #{platform[:platform]}" do
       cached(:chef_run) do

--- a/spec/unit/recipes/test_custom_repo_setup_recipe_spec.rb
+++ b/spec/unit/recipes/test_custom_repo_setup_recipe_spec.rb
@@ -5,7 +5,7 @@ describe 'test::custom_repo_setup_recipe' do
     cached(:centos_6) do
       ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version: '6.9',
+        version: '6.8',
         step_into: %w(chef_ingredient)
       ).converge(described_recipe)
     end

--- a/spec/unit/recipes/test_default_handler_spec.rb
+++ b/spec/unit/recipes/test_default_handler_spec.rb
@@ -47,7 +47,7 @@ describe 'test::default_handler' do
     let(:rhel_6) do
       ChefSpec::SoloRunner.new(
         platform: 'redhat',
-        version: '6.9',
+        version: '6.8',
         step_into: %w(chef_ingredient)
       ).converge(described_recipe)
     end

--- a/spec/unit/recipes/test_local_spec.rb
+++ b/spec/unit/recipes/test_local_spec.rb
@@ -5,7 +5,7 @@ describe 'test::local' do
     cached(:centos_6) do
       ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version: '6.9',
+        version: '6.8',
         step_into: %w(chef_ingredient chef_server_ingredient)
       ) do |node|
         node.normal['chef-server-core']['version'] = nil

--- a/spec/unit/recipes/test_push_spec.rb
+++ b/spec/unit/recipes/test_push_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'test::push' do
   [{ platform: 'ubuntu', version: '14.04' },
-   { platform: 'centos', version: '6.7' }].each do |platform|
+   { platform: 'centos', version: '6.8' }].each do |platform|
     context "non-platform specific resources on #{platform[:platform]}" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(
@@ -20,7 +20,7 @@ describe 'test::push' do
     cached(:centos_6) do
       ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version: '6.9',
+        version: '6.8',
         step_into: %w(chef_ingredient)
       ) do |node|
         node.normal['test']['push-client']['version'] = :latest

--- a/spec/unit/recipes/test_repo_spec.rb
+++ b/spec/unit/recipes/test_repo_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'test::repo' do
   [{ platform: 'ubuntu', version: '14.04' },
-   { platform: 'centos', version: '6.9' }].each do |platform|
+   { platform: 'centos', version: '6.8' }].each do |platform|
     context "non-platform specific resources on #{platform[:platform]}" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(
@@ -68,7 +68,7 @@ EOS
     cached(:centos_6) do
       ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version: '6.9',
+        version: '6.8',
         step_into: %w(chef_ingredient chef_ingredient)
       ) do |node|
         node.normal['chef-server-core']['version'] = nil
@@ -94,7 +94,7 @@ EOS
     cached(:centos_6) do
       ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version: '6.9',
+        version: '6.8',
         step_into: ['chef_ingredient']
       ) do |node|
         node.normal['test']['chef-server-core']['version'] = :latest
@@ -110,7 +110,7 @@ EOS
     cached(:centos_6) do
       ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version: '6.9',
+        version: '6.8',
         step_into: ['chef_ingredient']
       ) do |node|
         node.normal['test']['chef-server-core']['version'] = 'latest'

--- a/spec/unit/recipes/test_upgrade_spec.rb
+++ b/spec/unit/recipes/test_upgrade_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'test::upgrade' do
   [{ platform: 'ubuntu', version: '14.04' },
-   { platform: 'centos', version: '6.9' }].each do |platform|
+   { platform: 'centos', version: '6.8' }].each do |platform|
     context "non-platform specific resources on #{platform[:platform]}" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(
@@ -20,7 +20,7 @@ describe 'test::upgrade' do
     cached(:centos_6) do
       ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version: '6.9',
+        version: '6.8',
         step_into: %w(chef_ingredient)
       ) do |node|
         node.normal['chef-server-core']['version'] = :latest


### PR DESCRIPTION
Tests failing with Invalid platfrom for '6.9'

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
