### PR TITLE
Required for chef_server cookbook

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -256,6 +256,16 @@ module ChefIngredientCookbook
       end
     end
 
+    def fqdn_resolves?(fqdn)
+      require 'resolv'
+      Resolv.getaddress(fqdn)
+      return true
+    rescue Resolv::ResolvError, Resolv::ResolvTimeout
+      false
+    end
+
+    module_function :fqdn_resolves?
+
     def windows?
       node['platform_family'] == 'windows'
     end


### PR DESCRIPTION
The chef server cookbook fails because this method was removed at some
point. This adds it back as a helper method.

Signed-off-by: JJ Asghar <jj@chef.io>