### PR TITLE
Fixing path for wf_builder

### DIFF
--- a/resources/wf_builder.rb
+++ b/resources/wf_builder.rb
@@ -131,11 +131,12 @@ action :create do
   end
 
   %w(etc/delivery.rb .chef/knife.rb).each do |dir|
+    properpath = dir.split('/')
     file "#{workspace}/#{dir}" do
       content ensurekv(::File.read(new_resource.chef_config_path),
                        node_name: new_resource.chef_user,
                        log_location: :STDOUT,
-                       client_key: "#{workspace}/#{dir}/#{new_resource.chef_user}.pem",
+                       client_key: "#{workspace}/#{properpath[0]}/#{new_resource.chef_user}.pem",
                        trusted_certs_dir: '/etc/chef/trusted_certs')
       mode '0644'
       owner 'dbuild'


### PR DESCRIPTION
### Description

This update fixes a bug where the directory resource creating etc and .chef directories in the dbuild account are not created properly. This code splits the path in for the directories and uses the first part of the split to properly create the needed directories. 

### Issues Resolved

Fix incorrect directory path in dbuild account (/var/opt/delivery/workspace/etc and and /var/opt/delivery/workspace/.chef). 

### Check List

- [* ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [* ] New functionality includes testing.
- [* ] New functionality has been documented in the README if applicable
- [* ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Christopher Maher <defilan@gmail.com>

