### PR TITLE
Fixing pathing for etc and .chef directories for dbuild in wf_builder

### DIFF
--- a/resources/wf_builder.rb
+++ b/resources/wf_builder.rb
@@ -131,11 +131,12 @@ action :create do
   end
 
   %w(etc/delivery.rb .chef/knife.rb).each do |dir|
+    properpath = dir.split('/')
     file "#{workspace}/#{dir}" do
       content ensurekv(::File.read(new_resource.chef_config_path),
                        node_name: new_resource.chef_user,
                        log_location: :STDOUT,
-                       client_key: "#{workspace}/#{dir}/#{new_resource.chef_user}.pem",
+                       client_key: "#{workspace}/#{properpath[0]}/#{new_resource.chef_user}.pem",
                        trusted_certs_dir: '/etc/chef/trusted_certs')
       mode '0644'
       owner 'dbuild'


### PR DESCRIPTION
Signed-off-by: Christopher P. Maher <defilan@gmail.com>

### Description

This change fixes a bug where the client_key path for the file resource in wf_builder isn't correctly set. This passes the entire file path instead of the directory. 

### Issues Resolved

This fixes a bug that prevents wf_builder from finishing sucessfully as it fails on creating the correct file for dbuild user in /var/opt/delivery/workspace/etc and /var/opt/delivery/workspace/.chef.

### Check List

- [* ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [*] New functionality includes testing.
- [*] New functionality has been documented in the README if applicable
- [*] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
