### PR TITLE
Fix amazon linux support in Chef 13

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -44,13 +44,11 @@ platforms:
 - name: centos-6
   driver:
     image: dokken/centos-6
-    platform: rhel
     pid_one_command: /sbin/init
 
 - name: centos-7
   driver:
     image: dokken/centos-7
-    platform: rhel
     pid_one_command: /usr/lib/systemd/systemd
 
 - name: fedora-latest

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,9 @@ verifier:
   name: inspec
 
 platforms:
+  - name: amazonlinux
+    driver_config:
+      box: mvbcoding/awslinux
   - name: centos-6
   - name: centos-7
   - name: ubuntu-14.04
@@ -31,6 +34,11 @@ platforms:
   - name: windows-server-2012r2-standard
     driver:
       box: chef/windows-server-2012r2-standard # private
+      customize:
+        cpus: 4
+  - name: windows-server-2016-standard
+    driver_config:
+      box: chef/windows-server-2016-standard # private
       customize:
         cpus: 4
 
@@ -44,7 +52,7 @@ default: &default
 suites:
   - name: default
     <<: *default
-    excludes: [ 'macosx-10.12', 'windows-server-2012r2-standard' ]
+    excludes: [ 'macosx-10.12', 'windows-server-2012r2-standard', 'windows-server-2016-standard' ]
     run_list:
       <% if ENV['MIXLIB_INSTALL_GIT_REF'] %>
       - recipe[test::install_git]
@@ -54,14 +62,14 @@ suites:
 
   - name: local_package_install
     <<: *default
-    excludes: [ 'macosx-10.12', 'windows-server-2012r2-standard' ]
+    excludes: [ 'macosx-10.12', 'windows-server-2012r2-standard', 'windows-server-2016-standard'  ]
     run_list:
       - recipe[test]
       - recipe[test::local]
 
   - name: chefdk
     <<: *default
-    includes: [ 'ubuntu-14.04', 'ubuntu-16.04', 'centos-6', 'centos-7', 'macosx-10.12', 'windows-server-2012r2-standard' ]
+    includes: [ 'ubuntu-14.04', 'ubuntu-16.04', 'centos-6', 'centos-7', 'macosx-10.12', 'windows-server-2012r2-standard', 'windows-server-2016-standard'  ]
     run_list:
       <% if ENV['MIXLIB_INSTALL_GIT_REF'] %>
       - recipe[test::install_git]
@@ -71,7 +79,7 @@ suites:
 
   - name: inspec
     <<: *default
-    includes: [ 'ubuntu-14.04', 'ubuntu-16.04', 'centos-6', 'centos-7', 'macosx-10.12', 'windows-server-2012r2-standard' ]
+    includes: [ 'ubuntu-14.04', 'ubuntu-16.04', 'centos-6', 'centos-7', 'macosx-10.12', 'windows-server-2012r2-standard', 'windows-server-2016-standard'  ]
     run_list:
       <% if ENV['MIXLIB_INSTALL_GIT_REF'] %>
       - recipe[test::install_git]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,13 +21,13 @@ verifier:
   name: inspec
 
 platforms:
-  - name: centos-6.9
-  - name: centos-7.3
+  - name: centos-6
+  - name: centos-7
   - name: ubuntu-14.04
   - name: ubuntu-16.04
-  - name: macosx-10.11
+  - name: macosx-10.12
     driver:
-      box: chef/macosx-10.11 # private
+      box: chef/macosx-10.12 # private
   - name: windows-server-2012r2-standard
     driver:
       box: chef/windows-server-2012r2-standard # private
@@ -44,7 +44,7 @@ default: &default
 suites:
   - name: default
     <<: *default
-    excludes: [ 'macosx-10.10', 'windows-server-2012r2-standard' ]
+    excludes: [ 'macosx-10.12', 'windows-server-2012r2-standard' ]
     run_list:
       <% if ENV['MIXLIB_INSTALL_GIT_REF'] %>
       - recipe[test::install_git]
@@ -54,14 +54,14 @@ suites:
 
   - name: local_package_install
     <<: *default
-    excludes: [ 'macosx-10.10', 'windows-server-2012r2-standard' ]
+    excludes: [ 'macosx-10.12', 'windows-server-2012r2-standard' ]
     run_list:
       - recipe[test]
       - recipe[test::local]
 
   - name: chefdk
     <<: *default
-    includes: [ 'ubuntu-14.04', 'ubuntu-16.04', 'centos-6.9', 'centos-7.3', 'macosx-10.11', 'windows-server-2012r2-standard' ]
+    includes: [ 'ubuntu-14.04', 'ubuntu-16.04', 'centos-6', 'centos-7', 'macosx-10.12', 'windows-server-2012r2-standard' ]
     run_list:
       <% if ENV['MIXLIB_INSTALL_GIT_REF'] %>
       - recipe[test::install_git]
@@ -71,7 +71,7 @@ suites:
 
   - name: inspec
     <<: *default
-    includes: [ 'ubuntu-14.04', 'ubuntu-16.04', 'centos-6.9', 'centos-7.3', 'macosx-10.11', 'windows-server-2012r2-standard' ]
+    includes: [ 'ubuntu-14.04', 'ubuntu-16.04', 'centos-6', 'centos-7', 'macosx-10.12', 'windows-server-2012r2-standard' ]
     run_list:
       <% if ENV['MIXLIB_INSTALL_GIT_REF'] %>
       - recipe[test::install_git]
@@ -80,7 +80,7 @@ suites:
       - recipe[test::inspec]
 
   - name: chef_server
-    includes: [ 'ubuntu-16.04' ]
+    includes: [ 'ubuntu-16.04', 'centos-7' ]
     run_list:
       - recipe[test]
       - recipe[test::chef_server]

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ This delegates to the ctl command the service management command specified in th
 
 #### Properties
 
-- `service_name` -  The name of the service to manage. Specify this like `product_name/service`, for example, `chef-server/rabbitmq`.
-- `ctl_command` -  The "ctl" command, e.g. `chef-server-ctl`. This should be automatically detected by the library helper method `chef_ctl_command`, but may need to be specified if something changes, like a new add-on is made available.
+- `service_name` - The name of the service to manage. Specify this like `product_name/service`, for example, `chef-server/rabbitmq`.
+- `ctl_command` - The "ctl" command, e.g. `chef-server-ctl`. This should be automatically detected by the library helper method `chef_ctl_command`, but may need to be specified if something changes, like a new add-on is made available.
 
 ### ingredient_config
 
@@ -85,10 +85,9 @@ Makes it easy to create update configuration files of each Chef product. It uses
 
 #### Properties
 
-- `product_name` -  The product name. See the [PRODUCT_MATRIX.md](https://github.com/chef/mixlib-install/blob/master/PRODUCT_MATRIX.md). For example, `chef-server`, `analytics`, `delivery`, `manage`, etc.
+- `product_name` - The product name. See the [PRODUCT_MATRIX.md](https://github.com/chef/mixlib-install/blob/master/PRODUCT_MATRIX.md). For example, `chef-server`, `analytics`, `delivery`, `manage`, etc.
 - `config` - Content that will be added to the configuration file of the given product.
 - `sensitive` - Set to mask the config contents in logs. Use when you config contains information like passwords or secrets.
-
 
 #### Examples
 
@@ -122,7 +121,7 @@ ingredient_config "chef-server" do
 end
 ```
 
-To install or upgrade lastest version of Chef Client on your nodes:
+To install or upgrade latest version of Chef Client on your nodes:
 
 ```ruby
 chef_ingredient "chef" do
@@ -131,7 +130,7 @@ chef_ingredient "chef" do
 end
 ```
 
-To install an addon of Chef Server from `:current` channel:
+To install an add-on of Chef Server from `:current` channel:
 
 ```ruby
 chef_ingredient 'chef-server' do
@@ -164,6 +163,7 @@ These properties exist for all infrastructure resources
 Installs Chef Automate.
 
 #### Properties
+
 - `enterprise` - The Enterprise to create in Automate
 - `license` - we recommend using the chef_file resource
 - `chef_user` - The user you will connect to the Chef server as
@@ -176,8 +176,8 @@ Installs Chef Automate.
 #### Properties
 
 - `bootstrap_node` - The node we'll bootstrap secrets with.
-- `publish_address` - node['ipaddress']  | The address you want Chef-Backend to listen on.
-- `chef_backend_secrets` - A location where your secrets are |  we recommend using the chef_file resource.
+- `publish_address` - node['ipaddress'] | The address you want Chef-Backend to listen on.
+- `chef_backend_secrets` - A location where your secrets are | we recommend using the chef_file resource.
 
 ### chef_org
 
@@ -187,7 +187,7 @@ Installs Chef Automate.
 - `org_full_name` - The full name of the org you want to create.
 - `admins` - An array of admins for the org.
 - `users` - An array of users for the org.
-- `remove_users` - An array of users to remove from  the org.
+- `remove_users` - An array of users to remove from the org.
 - `key_path` - Where to store the validator key that is created with the org.
 
 ### chef_user
@@ -205,7 +205,7 @@ Installs Chef Automate.
 - `node_name` - The name of the node.
 - `version` - The version of chef-client to install.
 - `chefdk` - Do you want to install chefdk?
-- `chef_server_url` - What is hte Chef server URL to connect to.
+- `chef_server_url` - What is the Chef server URL to connect to.
 - `ssl_verify` - Validate ssl certificates?
 - `log_location` - Where to log.
 - `log_level` - Log level.
@@ -230,7 +230,7 @@ Installs Chef Automate.
 
 ### chef_server
 
-- `addons` - A set of addons to install with the Chef Server.
+- `addons` - A set of add-ons to install with the Chef Server.
 - `data_collector_token` - The data collector token to authenticate with Chef Visiblity.
 - `data_collector_url` - The URL to connect to Visibility.
 
@@ -258,15 +258,15 @@ Installs Chef Automate.
 
 ## License & Authors
 
-- Author: Joshua Timberman <joshua@chef.io>
-- Author: Serdar Sutay <serdar@chef.io>
-- Author: Patrick Wright <patrick@chef.io>
-- Author: Nathan Cerny <ncerny@chef.io>
-- Author: Andy Dufour <adufour@chef.io>
-- Author: Brandon Raabe <brandon.raabe@newcontext.com>
-- Author: Jeremy J. Miller <jm@chef.io>
-- Author: Josh Hudson <jhudson@chef.io>
-- Author: Stephen Lauck <lauck@chef.io>
+- Author: Joshua Timberman [joshua@chef.io](mailto:joshua@chef.io)
+- Author: Serdar Sutay [serdar@chef.io](mailto:serdar@chef.io)
+- Author: Patrick Wright [patrick@chef.io](mailto:patrick@chef.io)
+- Author: Nathan Cerny [ncerny@chef.io](mailto:ncerny@chef.io)
+- Author: Andy Dufour [adufour@chef.io](mailto:adufour@chef.io)
+- Author: Brandon Raabe [brandon.raabe@newcontext.com](mailto:brandon.raabe@newcontext.com)
+- Author: Jeremy J. Miller [jm@chef.io](mailto:jm@chef.io)
+- Author: Josh Hudson [jhudson@chef.io](mailto:jhudson@chef.io)
+- Author: Stephen Lauck [lauck@chef.io](mailto:lauck@chef.io)
 - Copyright (C) 2014-2017, Chef Software Inc. [legal@chef.io](mailto:legal@chef.io)
 
 ```text

--- a/libraries/default_handler.rb
+++ b/libraries/default_handler.rb
@@ -62,6 +62,7 @@ module ChefIngredient
           'debian'  => Chef::Provider::Package::Dpkg,
           'rhel'    => node['platform_version'].to_i == 5 ? Chef::Provider::Package::Rpm : Chef::Provider::Package::Yum,
           'suse'    => Chef::Provider::Package::Rpm,
+          'amazon'  => Chef::Provider::Package::Rpm,
           'windows' => Chef::Provider::Package::Windows
         )
         if new_resource.product_name == 'chef'

--- a/resources/chef_ingredient.rb
+++ b/resources/chef_ingredient.rb
@@ -113,7 +113,7 @@ action_class.class_eval do
   include ChefIngredientCookbook::Helpers
 
   case platform_family
-  when 'debian', 'rhel', 'suse', 'windows'
+  when 'debian', 'rhel', 'suse', 'windows', 'amazon'
     include ::ChefIngredient::DefaultHandler
   else
     # OmnitruckHandler is used for Solaris, AIX, FreeBSD, etc.


### PR DESCRIPTION
Amazon Linux has its own platform family in Chef 13. Add it in the 2 places it needs to be. Also add it to kitchen and do a bit of cleanup while we're in the files.