### PR TITLE
Require Chef 12.7 and stop using class_eval on action_class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ services: docker
 
 env:
   matrix:
+  - INSTANCE=chefdk-debian-7
+  - INSTANCE=chefdk-debian-8
+  - INSTANCE=chefdk-debian-9
   - INSTANCE=chefdk-centos-6
   - INSTANCE=chefdk-centos-7
   - INSTANCE=chefdk-centos-7 CHEF_VERSION=12.7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ env:
   matrix:
   - INSTANCE=chefdk-centos-6
   - INSTANCE=chefdk-centos-7
-  - INSTANCE=chefdk-centos-7 CHEF_VERSION=12.5.1
+  - INSTANCE=chefdk-centos-7 CHEF_VERSION=12.7.2
   - INSTANCE=chefdk-ubuntu-1404
   - INSTANCE=chefdk-ubuntu-1604
-  - INSTANCE=chefdk-ubuntu-1604 CHEF_VERSION=12.5.1
+  - INSTANCE=chefdk-ubuntu-1604 CHEF_VERSION=12.7.2
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/README.md
+++ b/README.md
@@ -18,12 +18,15 @@ It will perform component installation and configuration. It provides no recipes
 
 ### Platforms
 
-- Ubuntu 12.04, 14.04, 16.04
-- CentOS 6, 7
+- Ubuntu 14.04, 16.04
+- Debian 7/8/9
+- CentOS/RHEL 6, 7
+- openSUSE
+- Amazon Linux
 
 ### Chef
 
-- Chef 12.5+
+- Chef 12.7+
 
 ### Cookbooks
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,4 @@ end
 
 source_url 'https://github.com/chef-cookbooks/chef-ingredient'
 issues_url 'https://github.com/chef-cookbooks/chef-ingredient/issues'
-chef_version '>= 12.5' if respond_to?(:chef_version)
+chef_version '>= 12.7' if respond_to?(:chef_version)

--- a/resources/automate.rb
+++ b/resources/automate.rb
@@ -134,6 +134,6 @@ EOF
   end
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 end

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -93,6 +93,6 @@ action :create do
   end
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 end

--- a/resources/chef_ingredient.rb
+++ b/resources/chef_ingredient.rb
@@ -109,7 +109,7 @@ action :reconfigure do
   end
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 
   case platform_family

--- a/resources/chef_org.rb
+++ b/resources/chef_org.rb
@@ -71,6 +71,6 @@ action :create do
   end
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 end

--- a/resources/chef_user.rb
+++ b/resources/chef_user.rb
@@ -77,6 +77,6 @@ action :delete do
   end
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 end

--- a/resources/client.rb
+++ b/resources/client.rb
@@ -161,6 +161,6 @@ action :run do
   end
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 end

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -63,6 +63,6 @@ action :create do
   end
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 end

--- a/resources/ingredient_config.rb
+++ b/resources/ingredient_config.rb
@@ -40,6 +40,6 @@ action :add do
   add_config(new_resource.product_name, config)
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 end

--- a/resources/omnibus_service.rb
+++ b/resources/omnibus_service.rb
@@ -28,7 +28,7 @@ property :service_name, String, regex: %r{[\w-]+\/[\w-]+}, name_property: true
   end
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 
   #

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -75,6 +75,6 @@ action :create do
   end
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 end

--- a/resources/supermarket.rb
+++ b/resources/supermarket.rb
@@ -61,6 +61,6 @@ action :create do
   end
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 end

--- a/resources/wf_builder.rb
+++ b/resources/wf_builder.rb
@@ -306,6 +306,6 @@ action :create do
   end
 end
 
-action_class.class_eval do
+action_class do
   include ChefIngredientCookbook::Helpers
 end

--- a/test/fixtures/cookbooks/test/recipes/chefdk.rb
+++ b/test/fixtures/cookbooks/test/recipes/chefdk.rb
@@ -2,10 +2,12 @@ chef_ingredient 'install old chefdk version' do
   product_name 'chefdk'
   action :install
   version '1.5.0'
+  platform_version_compatibility_mode true
 end
 
 chef_ingredient 'upgrade to newer chefdk version' do
   product_name 'chefdk'
   action :upgrade
   version '2.0.28'
+  platform_version_compatibility_mode true
 end


### PR DESCRIPTION
So we had a bit of a rocky start with custom resources. 12.5 worked with class_eval, 12.6 didn't unless they were at the top of the file and a last chef 12 release (12.12/12.13 era) outright fails if you use class_eval. To get around this we require 12.7 everywhere we use custom resources and we don't do the class_eval. It works for older clients as well as new clients and 12.7 came out 18 months ago.