### PR TITLE
Create build_user group

### DIFF
--- a/resources/wf_builder.rb
+++ b/resources/wf_builder.rb
@@ -228,6 +228,8 @@ action :create do
       action [:create, :lock]
       home home_dir
     end
+    
+    group build_user
 
     directory home_dir do
       owner build_user


### PR DESCRIPTION
### Description

wf_builder ingredient failed with the following error:
```
           Chef::Exceptions::GroupIDNotFound
           ---------------------------------
           directory[/home/job_runner] (/tmp/kitchen/cache/cookbooks/chef-ingredient/resources/wf_builder.rb line 232) had an error: Chef::Exceptions::GroupIDNotFound: cannot determine group id for 'job_runner', does the group exist on this system?
```

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
