### PR TITLE
Fix permissions on chef-backend-secrets.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Installs Chef Automate.
 - `bootstrap_node` - The node we'll bootstrap secrets with.
 - `publish_address` - node['ipaddress'] | The address you want Chef-Backend to listen on.
 - `chef_backend_secrets` - A location where your secrets are | we recommend using the chef_file resource.
+- `chef_backend_secrets_user` - The user that owns the file created by the `chef_backend_secrets` attribute
+- `chef_backend_secrets_group` - The group that owns the file created by the `chef_backend_secrets` attribute
 
 ### chef_org
 

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -27,6 +27,8 @@ property :accept_license, [TrueClass, FalseClass], default: false
 property :peers, [String, Array], required: true
 property :publish_address, String, default: node['ipaddress']
 property :chef_backend_secrets, String, default: ''
+property :chef_backend_secrets_user, String, default: 'root'
+property :chef_backend_secrets_group, String, default: 'chef_pgsql'
 property :platform, String
 property :platform_version, String
 
@@ -60,9 +62,9 @@ action :create do
   chef_file '/etc/chef-backend/chef-backend-secrets.json' do
     sensitive new_resource.sensitive if new_resource.sensitive
     source new_resource.chef_backend_secrets
-    user 'root'
-    group 'root'
-    mode '0600'
+    user new_resource.chef_backend_secrets_user
+    group new_resource.chef_backend_secrets_group
+    mode '0640'
     not_if { new_resource.chef_backend_secrets.empty? }
   end
 


### PR DESCRIPTION
`/etc/chef-backend/chef-backend-secrets.json` must be readable by the user that the `chef-backend` services are running as in-order for cluster actions like leader failover and promotion to work.

This PR changes the mode of the secrets file from `0600` to `0640`, makes the user and group associated with the secrets file configurable, and defaults the file ownership to `root:chef_pgsql` (which is required for cluster operations to work when using default settings).

Two new properties have been added to this resource to allow for the secrets file ownership to be configurable:

```
chef_backend_secrets_user
chef_backend_secrets_group
```

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
