### PR TITLE
Add client.d folder provisioning to chef_client resource

### DIFF
--- a/resources/client.rb
+++ b/resources/client.rb
@@ -74,9 +74,11 @@ action :install do
     platform_version new_resource.platform_version if new_resource.platform_version
   end
 
-  directory ::File.join(prefix, 'config.d') do
-    mode '0755'
-    recursive true
+  %w( config.d client.d ).each do |d_folder|
+    directory ::File.join(prefix, d_folder) do
+      mode '0755'
+      recursive true
+    end
   end
 
   template 'client.rb' do


### PR DESCRIPTION
### Description

This adds directory creation for the chef config `client.d` folder pattern which was [introduced by default in Chef Client 12.8](https://docs.chef.io/config_rb_client.html). I figure with Chef 14 being upon us that this is a good time as any to introduce this.

### Issues Resolved

None

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
