### PR TITLE
Fix chef_org guards

### DIFF
--- a/resources/chef_org.rb
+++ b/resources/chef_org.rb
@@ -52,14 +52,14 @@ action :create do
   new_resource.users.each do |user|
     execute "add-user-#{user}-org-#{new_resource.org}" do
       command "chef-server-ctl org-user-add #{new_resource.org} #{user}"
-      only_if { node.run_state['chef-users'].index(/^#{user}$/) }
+      not_if { node.run_state['chef-users'].index(/^#{user}$/) }
     end
   end
 
   new_resource.admins.each do |user|
     execute "add-admin-#{user}-org-#{new_resource.org}" do
       command "chef-server-ctl org-user-add --admin #{new_resource.org} #{user}"
-      only_if { node.run_state['chef-users'].index(/^#{user}$/) }
+      not_if { node.run_state['chef-users'].index(/^#{user}$/) }
     end
   end
 


### PR DESCRIPTION
Signed-off-by: manulik <denismanulik@gmail.com>

### Description
Fix incorrect guards for chef_org resource. Current don't imply convergent execution of 'add-admin' and 'add-user' blocks

### Issues Resolved
Not specified

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
