### PR TITLE
Silence chef-25 deprecation from seven_zip cookbook

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -10,8 +10,9 @@ provisioner:
   name: dokken
   data_bags_path: test/fixtures/data_bags
   deprecations_as_errors: true
-  silence_deprecation_warnings:
-  - chef-25
+  client_rb:
+    silence_deprecation_warnings:
+    - chef-25
 
 verifier:
   name: inspec

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -10,6 +10,8 @@ provisioner:
   name: dokken
   data_bags_path: test/fixtures/data_bags
   deprecations_as_errors: true
+  silence_deprecation_warnings:
+  - chef-25
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -9,6 +9,8 @@ provisioner:
   name: chef_zero
   data_bags_path: test/fixtures/data_bags
   deprecations_as_errors: true
+  silence_deprecation_warnings:
+  - chef-25
   retry_on_exit_code:
     - 213
   max_retries: 1

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -9,8 +9,6 @@ provisioner:
   name: chef_zero
   data_bags_path: test/fixtures/data_bags
   deprecations_as_errors: true
-  silence_deprecation_warnings:
-  - chef-25
   retry_on_exit_code:
     - 213
   max_retries: 1
@@ -18,6 +16,8 @@ provisioner:
   client_rb:
     exit_status: :enabled
     client_fork: false
+    silence_deprecation_warnings:
+    - chef-25
 
 verifier:
   name: inspec


### PR DESCRIPTION
### Description

Silences the chef-25 deprecation cause by a transitive dependency (seven_zip) cookbook.

https://github.com/chef/chef/blob/master/RELEASE_NOTES.md#silencing-deprecation-warnings

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
