### PR TITLE
Pass sensitive

### DIFF
--- a/resources/automate.rb
+++ b/resources/automate.rb
@@ -122,6 +122,7 @@ EOF
   end
 
   ingredient_config 'automate' do
+    sensitive new_resource.sensitive if new_resource.sensitive
     notifies :reconfigure, 'chef_ingredient[automate]', :immediately
   end
 

--- a/resources/chef_org.rb
+++ b/resources/chef_org.rb
@@ -59,14 +59,14 @@ action :create do
   new_resource.admins.each do |user|
     execute "add-admin-#{user}-org-#{new_resource.org}" do
       command "chef-server-ctl org-user-add --admin #{new_resource.org} #{user}"
-      only_if { node.run_state['chef-users'].index(/^#{user}$/) }
+      not_if { node.run_state['chef-users'].index(/^#{user}$/) }
     end
   end
 
   new_resource.remove_users.each do |user|
     execute "remove-user-#{user}-org-#{new_resource.org}" do
       command "chef-server-ctl org-user-remove #{new_resource.org} #{user}"
-      only_if { node.run_state['chef-users'].index(/^#{user}$/) }
+      not_if { node.run_state['chef-users'].index(/^#{user}$/) }
     end
   end
 end

--- a/resources/chef_user.rb
+++ b/resources/chef_user.rb
@@ -55,6 +55,7 @@ action :create do
     block do
       node.run_state['chef-users'] << "#{new_resource.username}\n"
     end
+    not_if { node.run_state['chef-users'].index(/^#{new_resource.username}$/) }
   end
 
   execute "grant-server-admin-#{new_resource.username}" do


### PR DESCRIPTION
### Description

- Adds a guard to a ruby block inside the chef user resource
- Passes the sensitive property to the ingredient config resource inside the automate resource

### Issues Resolved

resolves #221 
resolves #170 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
