### PR TITLE
Honoring Chef Infra Server license accept

### DIFF
--- a/resources/chef_ingredient.rb
+++ b/resources/chef_ingredient.rb
@@ -79,7 +79,7 @@ action :reconfigure do
     ingredient_config new_resource.product_name do
       sensitive new_resource.sensitive if new_resource.sensitive
       action :render
-      not_if {get_config(new_resource.product_name).empty?}
+      not_if { get_config(new_resource.product_name).empty? }
     end
 
     # If accept_license is set, drop .license.accepted file so that

--- a/resources/chef_ingredient.rb
+++ b/resources/chef_ingredient.rb
@@ -79,7 +79,7 @@ action :reconfigure do
     ingredient_config new_resource.product_name do
       sensitive new_resource.sensitive if new_resource.sensitive
       action :render
-      not_if { get_config(new_resource.product_name).empty? }
+      not_if {get_config(new_resource.product_name).empty?}
     end
 
     # If accept_license is set, drop .license.accepted file so that
@@ -103,8 +103,15 @@ action :reconfigure do
       end
     end
 
+    reconfigure_command = case new_resource.accept_license && new_resource.product_name == 'chef-server'
+                          when true then
+                            'reconfigure --chef-license=accept'
+                          else
+                            'reconfigure'
+                          end
+
     execute "#{ingredient_package_name}-reconfigure" do
-      command "#{ingredient_ctl_command} reconfigure"
+      command "#{ingredient_ctl_command} #{reconfigure_command}"
     end
   end
 end

--- a/spec/unit/chef_automate_spec.rb
+++ b/spec/unit/chef_automate_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-ingredient
 # Spec:: chef_automate
 #
-# Copyright 2016 Chef Software Inc
+# Copyright:: 2016 Chef Software Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/chef_file_spec.rb
+++ b/spec/unit/chef_file_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-ingredient
 # Spec:: chef_file
 #
-# Copyright 2016 Chef Software Inc
+# Copyright:: 2016 Chef Software Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

Since the new Chef License it is not possible to install the Chef Infra Server without explicitly accepting the license

### Issues Resolved

 - some listing
 - Attribute `accept_license` also accepts the Chef Infra Server License now

### Check List

 - `delivery local all` succeeds
 - The README already states that `accept_license` will accept any license
 - kitchen failed for another reason not linked to this PR - Basically it works with the `chef-server` CB and our wrapper which brings 30+ Inspec tests to test every nook and cranny of a chef server install