### PR TITLE
Fix support for RHEL/CentOS 8

### DIFF
--- a/libraries/default_handler.rb
+++ b/libraries/default_handler.rb
@@ -60,7 +60,14 @@ module ChefIngredient
         timeout new_resource.timeout if new_resource.timeout
         provider value_for_platform_family(
           'debian' => Chef::Provider::Package::Dpkg,
-          'rhel' => node['platform_version'].to_i == 5 ? Chef::Provider::Package::Rpm : Chef::Provider::Package::Yum,
+          'rhel' => value_for_platform(
+            [ 'centos', 'redhat' ] => {
+              '~> 5.0' => Chef::Provider::Package::Rpm,
+              '~> 6.0' => Chef::Provider::Package::Yum,
+              '~> 7.0' => Chef::Provider::Package::Yum,
+              '>= 8.0' => Chef::Provider::Package::Dnf,
+            }
+          ),
           'suse' => Chef::Provider::Package::Rpm,
           'amazon' => Chef::Provider::Package::Rpm,
           'windows' => Chef::Provider::Package::Windows

--- a/spec/unit/recipes/test_default_handler_spec.rb
+++ b/spec/unit/recipes/test_default_handler_spec.rb
@@ -56,4 +56,30 @@ describe 'test::default_handler' do
       expect(rhel_6).to install_package('chef').with(provider: Chef::Provider::Package::Yum)
     end
   end
+  context 'install chef on rhel 7' do
+    let(:rhel_7) do
+      ChefSpec::SoloRunner.new(
+        platform: 'redhat',
+        version: '7',
+        step_into: %w(chef_ingredient)
+      ).converge(described_recipe)
+    end
+
+    it 'use the Yum package provider' do
+      expect(rhel_7).to install_package('chef').with(provider: Chef::Provider::Package::Yum)
+    end
+  end
+  context 'install chef on rhel 8' do
+    let(:rhel_8) do
+      ChefSpec::SoloRunner.new(
+        platform: 'redhat',
+        version: '8',
+        step_into: %w(chef_ingredient)
+      ).converge(described_recipe)
+    end
+
+    it 'use the Dnf package provider' do
+      expect(rhel_8).to install_package('chef').with(provider: Chef::Provider::Package::Dnf)
+    end
+  end
 end


### PR DESCRIPTION
RHEL 8 now ships with dnf as the primary package manager. This fix accounts for
the need to use the Dnf package provider instead of the defaulted Yum provider.
Without this, the converge will fail trying to use the Yum provider.

Signed-off-by: Lance Albertson <lance@osuosl.org>

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
