### PR TITLE
Make Chef Infra Server honor license acceptance

### DIFF
--- a/resources/chef_ingredient.rb
+++ b/resources/chef_ingredient.rb
@@ -103,8 +103,15 @@ action :reconfigure do
       end
     end
 
+    reconfigure_command = case new_resource.accept_license && new_resource.product_name == 'chef-server'
+                          when true then
+                            'reconfigure --chef-license=accept'
+                          else
+                            'reconfigure'
+                          end
+
     execute "#{ingredient_package_name}-reconfigure" do
-      command "#{ingredient_ctl_command} reconfigure"
+      command "#{ingredient_ctl_command} #{reconfigure_command}"
     end
   end
 end

--- a/resources/chef_ingredient.rb
+++ b/resources/chef_ingredient.rb
@@ -103,13 +103,6 @@ action :reconfigure do
       end
     end
 
-    reconfigure_command = case new_resource.accept_license && new_resource.product_name == 'chef-server'
-                          when true then
-                            'reconfigure --chef-license=accept'
-                          else
-                            'reconfigure'
-                          end
-
     execute "#{ingredient_package_name}-reconfigure" do
       command "#{ingredient_ctl_command} #{reconfigure_command}"
     end
@@ -126,5 +119,13 @@ action_class do
     # OmnitruckHandler is used for Solaris, AIX, FreeBSD, etc.
     # Eventually, we would like to support all platforms with the DefaultHandler
     include ::ChefIngredient::OmnitruckHandler
+  end
+
+  def reconfigure_command
+    if new_resource.accept_license && new_resource.product_name == 'chef-server'
+      'reconfigure --chef-license=accept'
+    else
+      'reconfigure'
+    end
   end
 end


### PR DESCRIPTION
Pulled this in from chef-cookbooks/chef-ingredient#241 since the original author hasn't been able to sign off on the commits and I want to upgrade to Chef Infra Server 13.

There are unrelated lint issues when I run `delivery local all`.

### Description

Pass license acceptance to `chef-server-ctl` when necessary.

### Issues Resolved



### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
