### PR TITLE
Fix Automate v2 deploy guard condition

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+ChefDeprecations/LogResourceNotifications:
+  Exclude:
+    # The proposed replacement is available from Chef Infra Client 15.8.
+    # This cookbook supports 13.0 and up.
+    - 'test/fixtures/cookbooks/test/recipes/omnibus_service.rb'

--- a/resources/automatev2.rb
+++ b/resources/automatev2.rb
@@ -45,7 +45,7 @@ action :create do
   execute "/usr/local/bin/chef-automate deploy #{Chef::Config[:file_cache_path]}/config.toml#{' --accept-terms-and-mlsa' if new_resource.accept_license}" do
     cwd Chef::Config[:file_cache_path]
     only_if { FileTest.file?("#{Chef::Config[:file_cache_path]}/config.toml") }
-    not_if 'chef-automate service-versions'
+    not_if '/usr/local/bin/chef-automate service-versions'
   end
 
   file "#{Chef::Config[:file_cache_path]}/custom_config.toml" do

--- a/test/fixtures/cookbooks/test/recipes/custom_repo_setup_recipe.rb
+++ b/test/fixtures/cookbooks/test/recipes/custom_repo_setup_recipe.rb
@@ -1,5 +1,5 @@
 # Configure a custom repository setup recipe
-node.normal['chef-ingredient']['custom-repo-recipe'] = 'custom_repo::awesome_custom_setup'
+node.default['chef-ingredient']['custom-repo-recipe'] = 'custom_repo::awesome_custom_setup'
 
 chef_ingredient 'chef-server' do
   action :install

--- a/test/integration/chef_automatev2/test_chef_automatev2_spec.rb
+++ b/test/integration/chef_automatev2/test_chef_automatev2_spec.rb
@@ -2,6 +2,14 @@
 #   its('exit_status') { should eq 0 }
 # end
 
+describe file('/usr/local/bin/chef-automate') do
+  it { should_not exist }
+end
+
+describe file('/usr/bin/chef-automate') do
+  it { should exist }
+end
+
 describe command('chef-automate version') do
   its('exit_status') { should eq 0 }
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
The `chef_automatev2` resource has a guard condition when executing the deploy command. All other uses of `chef-automate` have the full path, but the invocation in the guard does not.

### Issues Resolved
Fixes #258 

Includes #261

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>