### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ We may need to restart the RabbitMQ service on the Chef Server, for example when
 
 ```ruby
 template '/etc/opscode/chef-server.rb' do
-  notifies :restart, 'omnibus_service[chef-server-core/rabbitmq]'
+  notifies :restart, 'omnibus_service[chef-server/rabbitmq]'
 end
 
-omnibus_service 'chef-server-core/rabbitmq' do
+omnibus_service 'chef-server/rabbitmq' do
   action :nothing
 end
 ```


### PR DESCRIPTION
### Description

This `omnibus_server` resource uses the `::PRODUCT_MATRIX` global in mixlib-install to automatically fetch the `ctl_command` that should be used. The current example references `chef-server-core` which is no longer present in `::PRODUCT_MATRIX`. This PR just updates the example(s) in the `README.md` so they are accurate.

- https://github.com/chef-cookbooks/chef-ingredient/blob/b3b29b991d87555c5e7ccd0f06703b02695fffd8/libraries/helpers.rb#L44-L51
- https://github.com/chef-cookbooks/chef-ingredient/blob/b3b29b991d87555c5e7ccd0f06703b02695fffd8/resources/omnibus_service.rb#L35-L42

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>