### PR TITLE
Add deprecations to the automate, chef_client and wf_builder resources

### DIFF
--- a/resources/automate.rb
+++ b/resources/automate.rb
@@ -43,6 +43,8 @@ load_current_value do
 end
 
 action :create do
+  Chef::Log.warn('The chef_automate resource is deprecated as Chef Automate V1 is EOL.')
+
   required_config = <<-EOF
     delivery['chef_username'] = '#{new_resource.chef_user}'
     delivery['chef_private_key'] = '/etc/delivery/#{new_resource.chef_user}.pem'

--- a/resources/client.rb
+++ b/resources/client.rb
@@ -59,6 +59,8 @@ load_current_value do
 end
 
 action :install do
+  Chef::Log.warn('The chef_client resource is deprecated. Please use the chef_client_config resource in Chef Infra Client 16.6 or later: https://docs.chef.io/resources/chef_client_config/')
+
   chef_ingredient 'chef' do
     action :upgrade
     version new_resource.version

--- a/resources/wf_builder.rb
+++ b/resources/wf_builder.rb
@@ -45,6 +45,8 @@ load_current_value do
 end
 
 action :create do
+  Chef::Log.warn('The workflow_builder resource is deprecated as Chef Workflow (Delivery) is EOL')
+
   chef_ingredient 'chefdk' do
     action :upgrade
     channel new_resource.channel


### PR DESCRIPTION
These are for EOL products or have been replaced with functionality in
the client itself.

Signed-off-by: Tim Smith <tsmith@chef.io>